### PR TITLE
[codex] Add Jivo Oil to Mart item mapping

### DIFF
--- a/barcode/services/intercompany_transfer_service.py
+++ b/barcode/services/intercompany_transfer_service.py
@@ -20,6 +20,7 @@ from ..models import (
     PalletStatus,
 )
 from .scan_service import ScanService
+from .oitm_item_service import OitmItemReadError, OitmItemService
 
 
 class IntercompanyTransferError(ValueError):
@@ -27,6 +28,9 @@ class IntercompanyTransferError(ValueError):
 
 
 class IntercompanyTransferService:
+    JIVO_OIL_COMPANY_CODE = "JIVO_OIL"
+    JIVO_MART_COMPANY_CODE = "JIVO_MART"
+
     def __init__(self, user):
         self.user = user
 
@@ -147,6 +151,152 @@ class IntercompanyTransferService:
         if value not in (EntityType.BOX, EntityType.PALLET):
             raise IntercompanyTransferError("Transfer type must be BOX or PALLET.")
         return value
+
+    @classmethod
+    def _requires_jivo_mart_item_mapping(cls, source: Company, destination: Company) -> bool:
+        return (
+            str(source.code or "").upper() == cls.JIVO_OIL_COMPANY_CODE
+            and str(destination.code or "").upper() == cls.JIVO_MART_COMPANY_CODE
+        )
+
+    def _destination_item_code_map(self, source: Company, destination: Company, boxes: list[Box]) -> dict[str, str]:
+        if not self._requires_jivo_mart_item_mapping(source, destination):
+            return {}
+
+        oil_item_codes = sorted({str(box.item_code or "").strip() for box in boxes})
+        mapper = OitmItemService(company_code=destination.code)
+        destination_codes: dict[str, str] = {}
+        for oil_item_code in oil_item_codes:
+            try:
+                matches = mapper.find_item_codes_by_oil_item_code(oil_item_code)
+            except OitmItemReadError as exc:
+                raise IntercompanyTransferError(str(exc)) from exc
+
+            if not matches:
+                raise IntercompanyTransferError(
+                    "Item mapping not found in Jivo Mart for Oil ItemCode: "
+                    f"{oil_item_code}. Please maintain U_Oil_ItemCode in Jivo Mart OITM table."
+                )
+            if len(matches) > 1:
+                raise IntercompanyTransferError(
+                    "Duplicate item mapping found in Jivo Mart for Oil ItemCode: "
+                    f"{oil_item_code}. Please correct duplicate U_Oil_ItemCode values in Jivo Mart OITM table."
+                )
+            destination_codes[oil_item_code] = matches[0]
+        return destination_codes
+
+    @staticmethod
+    def _move_boxes_to_destination(
+        *,
+        boxes: list[Box],
+        destination: Company,
+        destination_item_code_by_oil_code: dict[str, str],
+    ) -> None:
+        if not destination_item_code_by_oil_code:
+            Box.objects.filter(id__in=[box.id for box in boxes]).update(company=destination)
+            BarcodeMaster.objects.filter(box_id__in=[box.id for box in boxes]).update(company=destination)
+            return
+
+        now = timezone.now()
+        for box in boxes:
+            oil_item_code = str(box.item_code or "").strip()
+            box.company = destination
+            box.item_code = destination_item_code_by_oil_code[oil_item_code]
+            box.updated_at = now
+        Box.objects.bulk_update(boxes, ["company", "item_code", "updated_at"])
+
+        for destination_item_code in destination_item_code_by_oil_code.values():
+            box_ids = [box.id for box in boxes if box.item_code == destination_item_code]
+            BarcodeMaster.objects.filter(box_id__in=box_ids).update(
+                company=destination,
+                material_code=destination_item_code,
+            )
+
+    @staticmethod
+    def _move_pallets_to_destination(
+        *,
+        pallets: list[Pallet],
+        destination: Company,
+        destination_item_code_by_oil_code: dict[str, str],
+    ) -> None:
+        if not pallets:
+            return
+        if not destination_item_code_by_oil_code:
+            Pallet.objects.filter(id__in=[pallet.id for pallet in pallets]).update(company=destination)
+            BarcodeMaster.objects.filter(pallet_id__in=[pallet.id for pallet in pallets]).update(
+                company=destination
+            )
+            return
+
+        now = timezone.now()
+        for pallet in pallets:
+            oil_item_code = str(pallet.item_code or "").strip()
+            pallet.company = destination
+            if oil_item_code in destination_item_code_by_oil_code:
+                pallet.item_code = destination_item_code_by_oil_code[oil_item_code]
+            pallet.updated_at = now
+        Pallet.objects.bulk_update(pallets, ["company", "item_code", "updated_at"])
+
+        for destination_item_code in destination_item_code_by_oil_code.values():
+            pallet_ids = [pallet.id for pallet in pallets if pallet.item_code == destination_item_code]
+            BarcodeMaster.objects.filter(pallet_id__in=pallet_ids).update(
+                company=destination,
+                material_code=destination_item_code,
+            )
+
+    @staticmethod
+    def _restore_boxes_to_source(
+        *,
+        boxes: list[Box],
+        source: Company,
+        oil_item_code_by_box_id: dict[int, str],
+    ) -> None:
+        if not oil_item_code_by_box_id:
+            Box.objects.filter(id__in=[box.id for box in boxes]).update(company=source)
+            BarcodeMaster.objects.filter(box_id__in=[box.id for box in boxes]).update(company=source)
+            return
+
+        now = timezone.now()
+        for box in boxes:
+            box.company = source
+            box.item_code = oil_item_code_by_box_id.get(box.id, box.item_code)
+            box.updated_at = now
+        Box.objects.bulk_update(boxes, ["company", "item_code", "updated_at"])
+
+        for box in boxes:
+            BarcodeMaster.objects.filter(box_id=box.id).update(
+                company=source,
+                material_code=box.item_code,
+            )
+
+    @staticmethod
+    def _restore_pallets_to_source(
+        *,
+        pallets: list[Pallet],
+        source: Company,
+        oil_item_code_by_pallet_id: dict[int, str],
+    ) -> None:
+        if not pallets:
+            return
+        if not oil_item_code_by_pallet_id:
+            Pallet.objects.filter(id__in=[pallet.id for pallet in pallets]).update(company=source)
+            BarcodeMaster.objects.filter(pallet_id__in=[pallet.id for pallet in pallets]).update(
+                company=source
+            )
+            return
+
+        now = timezone.now()
+        for pallet in pallets:
+            pallet.company = source
+            pallet.item_code = oil_item_code_by_pallet_id.get(pallet.id, pallet.item_code)
+            pallet.updated_at = now
+        Pallet.objects.bulk_update(pallets, ["company", "item_code", "updated_at"])
+
+        for pallet in pallets:
+            BarcodeMaster.objects.filter(pallet_id=pallet.id).update(
+                company=source,
+                material_code=pallet.item_code,
+            )
 
     def _active_pallet_boxes(self, pallet: Pallet) -> list[Box]:
         return list(
@@ -271,6 +421,11 @@ class IntercompanyTransferService:
                 box_ids.add(box.id)
                 boxes.append(box)
 
+        destination_item_code_by_oil_code = self._destination_item_code_map(
+            source,
+            destination,
+            boxes,
+        )
         boxes = list(
             Box.objects
             .select_for_update()
@@ -317,12 +472,16 @@ class IntercompanyTransferService:
         ]
         IntercompanyTransferLine.objects.bulk_create(lines)
 
-        Box.objects.filter(id__in=[box.id for box in boxes]).update(company=destination)
-        BarcodeMaster.objects.filter(box_id__in=[box.id for box in boxes]).update(company=destination)
+        self._move_boxes_to_destination(
+            boxes=boxes,
+            destination=destination,
+            destination_item_code_by_oil_code=destination_item_code_by_oil_code,
+        )
         if transfer_type == EntityType.PALLET:
-            Pallet.objects.filter(id__in=[pallet.id for pallet in pallets]).update(company=destination)
-            BarcodeMaster.objects.filter(pallet_id__in=[pallet.id for pallet in pallets]).update(
-                company=destination
+            self._move_pallets_to_destination(
+                pallets=pallets,
+                destination=destination,
+                destination_item_code_by_oil_code=destination_item_code_by_oil_code,
             )
 
         BarcodeAuditLog.objects.bulk_create([
@@ -356,7 +515,8 @@ class IntercompanyTransferService:
         if transfer.status == IntercompanyTransferStatus.REVERSED:
             raise IntercompanyTransferError("Transfer is already reversed.")
 
-        boxes = [line.box for line in transfer.lines.all()]
+        lines = list(transfer.lines.all())
+        boxes = [line.box for line in lines]
         for box in boxes:
             if box.company_id != transfer.destination_company_id:
                 raise IntercompanyTransferError(
@@ -365,15 +525,32 @@ class IntercompanyTransferService:
             if box.dispatched_at or box.status == BoxStatus.DISPATCHED:
                 raise IntercompanyTransferError(f"{box.box_barcode} is already dispatched and cannot be reversed.")
 
-        Box.objects.filter(id__in=[box.id for box in boxes]).update(company=transfer.source_company)
-        BarcodeMaster.objects.filter(box_id__in=[box.id for box in boxes]).update(
-            company=transfer.source_company
+        is_mapped_route = self._requires_jivo_mart_item_mapping(
+            transfer.source_company,
+            transfer.destination_company,
+        )
+        oil_item_code_by_box_id = (
+            {line.box_id: line.item_code for line in lines}
+            if is_mapped_route
+            else {}
+        )
+        self._restore_boxes_to_source(
+            boxes=boxes,
+            source=transfer.source_company,
+            oil_item_code_by_box_id=oil_item_code_by_box_id,
         )
         if transfer.entity_type == EntityType.PALLET:
             pallet_ids = {box.pallet_id for box in boxes if box.pallet_id}
-            Pallet.objects.filter(id__in=pallet_ids).update(company=transfer.source_company)
-            BarcodeMaster.objects.filter(pallet_id__in=pallet_ids).update(
-                company=transfer.source_company
+            pallets = list(Pallet.objects.select_for_update().filter(id__in=pallet_ids))
+            oil_item_code_by_pallet_id = {}
+            if is_mapped_route:
+                for line in lines:
+                    if line.box.pallet_id:
+                        oil_item_code_by_pallet_id.setdefault(line.box.pallet_id, line.item_code)
+            self._restore_pallets_to_source(
+                pallets=pallets,
+                source=transfer.source_company,
+                oil_item_code_by_pallet_id=oil_item_code_by_pallet_id,
             )
         transfer.status = IntercompanyTransferStatus.REVERSED
         transfer.reversed_at = timezone.now()

--- a/barcode/services/oitm_item_service.py
+++ b/barcode/services/oitm_item_service.py
@@ -78,6 +78,31 @@ class OitmItemService:
             logger.error('Failed to fetch OITM item rows: %s', exc)
             raise OitmItemReadError(str(exc))
 
+    def find_item_codes_by_oil_item_code(self, oil_item_code: str) -> list[str]:
+        oil_item_code = str(oil_item_code or '').strip()
+        if not oil_item_code:
+            return []
+
+        schema = self.client.context.config['hana']['schema']
+        sql = """
+            SELECT
+                "ItemCode"
+            FROM "{schema}"."{table_name}"
+            WHERE "U_Oil_ItemCode" = ?
+        """.format(
+            schema=schema,
+            table_name=self.TABLE_NAME,
+        )
+
+        try:
+            rows = self._execute(sql, (oil_item_code,))
+            return [row.get('ItemCode') for row in rows if row.get('ItemCode')]
+        except OitmItemReadError:
+            raise
+        except Exception as exc:
+            logger.error('Failed to fetch Jivo Mart item mapping for %s: %s', oil_item_code, exc)
+            raise OitmItemReadError(str(exc))
+
     @staticmethod
     def _normalize_row(row: dict) -> dict:
         return {
@@ -105,7 +130,9 @@ class OitmItemService:
         except (InvalidOperation, ValueError, TypeError):
             return None
 
-    def _execute(self, sql: str) -> list[dict]:
+    def _execute(self, sql: str, params: tuple | list | None = None) -> list[dict]:
+        connection = None
+        cursor = None
         try:
             conn = self.client.context.hana
             from hdbcli import dbapi
@@ -117,11 +144,23 @@ class OitmItemService:
                 password=conn['password'],
             )
             cursor = connection.cursor()
-            cursor.execute(sql)
+            if params is None:
+                cursor.execute(sql)
+            else:
+                cursor.execute(sql, params)
             cols = [col[0] for col in cursor.description]
             rows = cursor.fetchall()
-            cursor.close()
-            connection.close()
             return [dict(zip(cols, row)) for row in rows]
         except Exception as exc:
             raise OitmItemReadError(str(exc))
+        finally:
+            if cursor is not None:
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+            if connection is not None:
+                try:
+                    connection.close()
+                except Exception:
+                    pass

--- a/barcode/tests.py
+++ b/barcode/tests.py
@@ -31,6 +31,7 @@ from .models import (
     DispatchSapUpdateStatus,
     DispatchSessionStatus,
     DispatchSettings,
+    IntercompanyTransfer,
     IntercompanyTransferStatus,
     ScanLog,
     ScanResult,
@@ -43,6 +44,7 @@ from .serializers import (
 )
 from .services.barcode_service import BarcodeService
 from .services.label_service import LabelService
+from .services.oitm_item_service import OitmItemService
 from .services.production_release_service import ProductionReleaseOilService
 from .services.scan_service import ScanService
 from .services.dispatch_service import (
@@ -78,6 +80,32 @@ class BarcodeWorkflowTests(TestCase):
         return self.service.generate_boxes(
             {
                 'item_code': 'FG001',
+                'item_name': 'Test Finished Good',
+                'batch_number': batch,
+                'qty': Decimal(qty),
+                'box_count': count,
+                'uom': 'PCS',
+                'mfg_date': date(2026, 5, 7),
+                'exp_date': date(2027, 5, 7),
+                'warehouse': 'FG01',
+                'production_line': line,
+            },
+            user=self.user,
+        )
+
+    def _generate_boxes_for_company(
+        self,
+        company_code,
+        *,
+        count=1,
+        item_code='FG001',
+        qty='12.50',
+        line='Line 1',
+        batch='BATCH-001',
+    ):
+        return BarcodeService(company_code=company_code).generate_boxes(
+            {
+                'item_code': item_code,
                 'item_name': 'Test Finished Good',
                 'batch_number': batch,
                 'qty': Decimal(qty),
@@ -557,6 +585,188 @@ class BarcodeWorkflowTests(TestCase):
         boxes[0].refresh_from_db()
         self.assertEqual(boxes[0].company_id, self.company.id)
 
+    @patch('barcode.services.intercompany_transfer_service.OitmItemService')
+    def test_intercompany_oil_to_mart_maps_destination_item_code(self, mock_oitm_service):
+        source = Company.objects.create(name='JIVO OIL', code='JIVO_OIL')
+        destination = Company.objects.create(name='JIVO MART', code='JIVO_MART')
+        role = UserRole.objects.create(name='Supervisor')
+        UserCompany.objects.create(user=self.user, company=source, role=role, is_active=True)
+        UserCompany.objects.create(user=self.user, company=destination, role=role, is_active=True)
+        box = self._generate_boxes_for_company(
+            source.code,
+            item_code='OIL-FG-001',
+            batch='BATCH-MAP',
+        )[0]
+        mock_oitm_service.return_value.find_item_codes_by_oil_item_code.return_value = ['MART-FG-009']
+
+        service = IntercompanyTransferService(self.user)
+        transfer = service.create_transfer(
+            source_company_code=source.code,
+            destination_company_code=destination.code,
+            barcodes=[box.box_barcode],
+            notes='Move mapped item',
+        )
+
+        mock_oitm_service.assert_called_once_with(company_code=destination.code)
+        mock_oitm_service.return_value.find_item_codes_by_oil_item_code.assert_called_once_with('OIL-FG-001')
+        line = transfer.lines.get()
+        self.assertEqual(line.item_code, 'OIL-FG-001')
+        self.assertEqual(line.batch_number, 'BATCH-MAP')
+        self.assertEqual(line.qty, Decimal('12.500'))
+        self.assertEqual(line.uom, 'PCS')
+        box.refresh_from_db()
+        self.assertEqual(box.company_id, destination.id)
+        self.assertEqual(box.item_code, 'MART-FG-009')
+        self.assertEqual(box.batch_number, 'BATCH-MAP')
+        self.assertEqual(box.qty, Decimal('12.50'))
+        self.assertEqual(box.uom, 'PCS')
+        self.assertEqual(box.current_warehouse, 'FG01')
+
+        reversed_transfer = service.reverse_transfer(transfer.id, reason='Reverse mapped item')
+        self.assertEqual(reversed_transfer.status, IntercompanyTransferStatus.REVERSED)
+        box.refresh_from_db()
+        self.assertEqual(box.company_id, source.id)
+        self.assertEqual(box.item_code, 'OIL-FG-001')
+
+    @patch('barcode.services.intercompany_transfer_service.OitmItemService')
+    def test_intercompany_oil_to_mart_rejects_missing_item_mapping(self, mock_oitm_service):
+        source = Company.objects.create(name='JIVO OIL', code='JIVO_OIL')
+        destination = Company.objects.create(name='JIVO MART', code='JIVO_MART')
+        role = UserRole.objects.create(name='Supervisor')
+        UserCompany.objects.create(user=self.user, company=source, role=role, is_active=True)
+        UserCompany.objects.create(user=self.user, company=destination, role=role, is_active=True)
+        box = self._generate_boxes_for_company(
+            source.code,
+            item_code='OIL-FG-MISSING',
+            batch='BATCH-NOMAP',
+        )[0]
+        mock_oitm_service.return_value.find_item_codes_by_oil_item_code.return_value = []
+        transfer_count = IntercompanyTransfer.objects.count()
+
+        with self.assertRaisesMessage(
+            IntercompanyTransferError,
+            'Item mapping not found in Jivo Mart for Oil ItemCode: OIL-FG-MISSING. '
+            'Please maintain U_Oil_ItemCode in Jivo Mart OITM table.',
+        ):
+            IntercompanyTransferService(self.user).create_transfer(
+                source_company_code=source.code,
+                destination_company_code=destination.code,
+                barcodes=[box.box_barcode],
+            )
+
+        box.refresh_from_db()
+        self.assertEqual(box.company_id, source.id)
+        self.assertEqual(box.item_code, 'OIL-FG-MISSING')
+        self.assertEqual(IntercompanyTransfer.objects.count(), transfer_count)
+
+    @patch('barcode.services.intercompany_transfer_service.OitmItemService')
+    def test_intercompany_oil_to_mart_rejects_duplicate_item_mapping(self, mock_oitm_service):
+        source = Company.objects.create(name='JIVO OIL', code='JIVO_OIL')
+        destination = Company.objects.create(name='JIVO MART', code='JIVO_MART')
+        role = UserRole.objects.create(name='Supervisor')
+        UserCompany.objects.create(user=self.user, company=source, role=role, is_active=True)
+        UserCompany.objects.create(user=self.user, company=destination, role=role, is_active=True)
+        box = self._generate_boxes_for_company(
+            source.code,
+            item_code='OIL-FG-DUP',
+            batch='BATCH-DUPMAP',
+        )[0]
+        mock_oitm_service.return_value.find_item_codes_by_oil_item_code.return_value = [
+            'MART-FG-001',
+            'MART-FG-002',
+        ]
+        transfer_count = IntercompanyTransfer.objects.count()
+
+        with self.assertRaisesMessage(
+            IntercompanyTransferError,
+            'Duplicate item mapping found in Jivo Mart for Oil ItemCode: OIL-FG-DUP. '
+            'Please correct duplicate U_Oil_ItemCode values in Jivo Mart OITM table.',
+        ):
+            IntercompanyTransferService(self.user).create_transfer(
+                source_company_code=source.code,
+                destination_company_code=destination.code,
+                barcodes=[box.box_barcode],
+            )
+
+        box.refresh_from_db()
+        self.assertEqual(box.company_id, source.id)
+        self.assertEqual(box.item_code, 'OIL-FG-DUP')
+        self.assertEqual(IntercompanyTransfer.objects.count(), transfer_count)
+
+    @patch('barcode.services.intercompany_transfer_service.OitmItemService')
+    def test_intercompany_oil_to_mart_rejects_blank_or_null_mapping(self, mock_oitm_service):
+        source = Company.objects.create(name='JIVO OIL', code='JIVO_OIL')
+        destination = Company.objects.create(name='JIVO MART', code='JIVO_MART')
+        role = UserRole.objects.create(name='Supervisor')
+        UserCompany.objects.create(user=self.user, company=source, role=role, is_active=True)
+        UserCompany.objects.create(user=self.user, company=destination, role=role, is_active=True)
+        box = self._generate_boxes_for_company(
+            source.code,
+            item_code='OIL-FG-BLANK',
+            batch='BATCH-BLANKMAP',
+        )[0]
+        mock_oitm_service.return_value.find_item_codes_by_oil_item_code.return_value = []
+        transfer_count = IntercompanyTransfer.objects.count()
+
+        with self.assertRaisesMessage(
+            IntercompanyTransferError,
+            'Item mapping not found in Jivo Mart for Oil ItemCode: OIL-FG-BLANK. '
+            'Please maintain U_Oil_ItemCode in Jivo Mart OITM table.',
+        ):
+            IntercompanyTransferService(self.user).create_transfer(
+                source_company_code=source.code,
+                destination_company_code=destination.code,
+                barcodes=[box.box_barcode],
+            )
+
+        box.refresh_from_db()
+        self.assertEqual(box.company_id, source.id)
+        self.assertEqual(box.item_code, 'OIL-FG-BLANK')
+        self.assertEqual(IntercompanyTransfer.objects.count(), transfer_count)
+
+    @patch('barcode.services.intercompany_transfer_service.OitmItemService')
+    def test_intercompany_item_mapping_is_skipped_for_other_company_pairs(self, mock_oitm_service):
+        destination = Company.objects.create(name='JIVO MART', code='JIVO_MART')
+        role = UserRole.objects.create(name='Supervisor')
+        UserCompany.objects.create(user=self.user, company=self.company, role=role, is_active=True)
+        UserCompany.objects.create(user=self.user, company=destination, role=role, is_active=True)
+        box = self._generate_boxes(count=1, batch='BATCH-SKIP')[0]
+
+        IntercompanyTransferService(self.user).create_transfer(
+            source_company_code=self.company.code,
+            destination_company_code=destination.code,
+            barcodes=[box.box_barcode],
+        )
+
+        mock_oitm_service.assert_not_called()
+        box.refresh_from_db()
+        self.assertEqual(box.company_id, destination.id)
+        self.assertEqual(box.item_code, 'FG001')
+
+    @patch('barcode.services.intercompany_transfer_service.OitmItemService')
+    def test_intercompany_oil_to_mart_scan_does_not_resolve_destination_mapping(self, mock_oitm_service):
+        source = Company.objects.create(name='JIVO OIL', code='JIVO_OIL')
+        destination = Company.objects.create(name='JIVO MART', code='JIVO_MART')
+        role = UserRole.objects.create(name='Supervisor')
+        UserCompany.objects.create(user=self.user, company=source, role=role, is_active=True)
+        UserCompany.objects.create(user=self.user, company=destination, role=role, is_active=True)
+        box = self._generate_boxes_for_company(
+            source.code,
+            item_code='OIL-FG-SCAN',
+            batch='BATCH-SCAN',
+        )[0]
+
+        scan = IntercompanyTransferService(self.user).scan_barcode(
+            barcode=json.dumps({'type': 'BOX', 'box_barcode': box.box_barcode}),
+            source_company_code=source.code,
+            destination_company_code=destination.code,
+        )
+
+        mock_oitm_service.assert_not_called()
+        self.assertEqual(scan['barcode'], box.box_barcode)
+        self.assertEqual(scan['item_code'], 'OIL-FG-SCAN')
+        self.assertEqual(scan['current_company'], source.code)
+
     def test_intercompany_scan_accepts_legacy_qr_payload_and_one_dimensional_value(self):
         destination = Company.objects.create(name='JIVO MART', code='JMART')
         role = UserRole.objects.create(name='Supervisor')
@@ -976,6 +1186,36 @@ class BarcodeWorkflowTests(TestCase):
         self.assertEqual(row['box_size'], '4')
         self.assertEqual(row['mfg_date'], '2026-02-20')
         self.assertEqual(row['exp_date'], '2027-02-20')
+
+    @patch('barcode.services.oitm_item_service.SAPClient')
+    def test_oitm_item_service_looks_up_jivo_mart_item_by_oil_item_code(self, mock_sap_client):
+        mock_sap_client.return_value.context.config = {
+            'hana': {'schema': 'JIVO_MART_HANADB'},
+        }
+        service = OitmItemService(company_code='JIVO_MART')
+
+        with patch.object(service, '_execute') as execute:
+            self.assertEqual(service.find_item_codes_by_oil_item_code('   '), [])
+            execute.assert_not_called()
+
+        with patch.object(
+            service,
+            '_execute',
+            return_value=[
+                {'ItemCode': 'MART-FG-009'},
+                {'ItemCode': ''},
+                {'ItemCode': None},
+            ],
+        ) as execute:
+            self.assertEqual(
+                service.find_item_codes_by_oil_item_code('OIL-FG-001'),
+                ['MART-FG-009'],
+            )
+
+        sql, params = execute.call_args.args
+        self.assertIn('FROM "JIVO_MART_HANADB"."OITM"', sql)
+        self.assertIn('WHERE "U_Oil_ItemCode" = ?', sql)
+        self.assertEqual(params, ('OIL-FG-001',))
 
 
 class FakeDispatchSapAdapter:

--- a/docs/JIVO_OIL_TO_MART_ITEM_MAPPING.md
+++ b/docs/JIVO_OIL_TO_MART_ITEM_MAPPING.md
@@ -1,0 +1,96 @@
+# Jivo Oil to Jivo Mart Item Mapping
+
+## Branch
+
+Created branch:
+
+```text
+fix/jivo-oil-mart-item-mapping
+```
+
+## What Changed
+
+- Added Jivo Oil to Jivo Mart item-code mapping for Barcode Intercompany Transfer.
+- Applied the mapping only when:
+  - Source Company is `JIVO_OIL`
+  - Destination Company is `JIVO_MART`
+- Added a Jivo Mart OITM lookup by Oil item code:
+
+```sql
+SELECT "ItemCode"
+FROM "OITM"
+WHERE "U_Oil_ItemCode" = :OilItemCode;
+```
+
+- Preserved the original Oil ItemCode on the transfer line for source-side traceability and reversal.
+- Updated destination-owned boxes and pallets to use the mapped Jivo Mart ItemCode after transfer.
+- Restored the original Oil ItemCode when an Oil to Mart transfer is reversed.
+- Kept barcode scan validation unchanged; the mapping is resolved during transfer confirmation before destination ownership is applied.
+- Kept all other company transfer combinations on the existing logic.
+
+## Error Handling
+
+- If no Jivo Mart item is mapped:
+
+```text
+Item mapping not found in Jivo Mart for Oil ItemCode: <OilItemCode>. Please maintain U_Oil_ItemCode in Jivo Mart OITM table.
+```
+
+- If multiple Jivo Mart items are mapped:
+
+```text
+Duplicate item mapping found in Jivo Mart for Oil ItemCode: <OilItemCode>. Please correct duplicate U_Oil_ItemCode values in Jivo Mart OITM table.
+```
+
+## Verification
+
+Latest focused Intercompany/OITM tests:
+
+```powershell
+$env:DEBUG='False'; .\.venv\Scripts\python.exe manage.py test barcode.tests.BarcodeWorkflowTests.test_oitm_item_service_looks_up_jivo_mart_item_by_oil_item_code barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_maps_destination_item_code barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_rejects_missing_item_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_rejects_duplicate_item_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_rejects_blank_or_null_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_item_mapping_is_skipped_for_other_company_pairs barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_scan_does_not_resolve_destination_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_scan_accepts_legacy_qr_payload_and_one_dimensional_value barcode.tests.BarcodeWorkflowTests.test_intercompany_transfer_api_end_to_end --keepdb
+```
+
+Result:
+
+```text
+Ran 9 tests in 11.466s
+OK
+```
+
+Broader Barcode workflow tests:
+
+```powershell
+$env:DEBUG='False'; .\.venv\Scripts\python.exe manage.py test barcode.tests.BarcodeWorkflowTests --keepdb
+```
+
+Result:
+
+```text
+Ran 35 tests in 43.795s
+OK
+```
+
+Runtime smoke checks:
+
+```text
+Frontend http://127.0.0.1:5173/ returned 200 OK
+Backend http://127.0.0.1:8000/admin/ returned 200 OK
+Django system check identified no issues
+```
+
+## Test Scope Result
+
+| Scope | Result |
+| --- | --- |
+| Successful Jivo Oil to Jivo Mart transfer | Passed. Transfer line keeps Oil ItemCode; destination box uses mapped Mart ItemCode. |
+| Missing mapping | Passed. Transfer stops with the required missing mapping error. |
+| Duplicate mapping | Passed. Transfer stops with the required duplicate mapping error. |
+| Blank or null mapping | Passed. Blank/null behaves as no valid mapping and transfer does not proceed. |
+| Other company combinations | Passed. OITM mapping service is not called and existing transfer behavior remains unchanged. |
+| Barcode scanning flow | Passed. Scan returns the Oil-side barcode/item data and does not resolve destination mapping during scan. |
+| Quantity, warehouse, batch, and stock fields | Passed for app-level transfer records. Quantity, UOM, batch, and warehouse remain unchanged while only the destination ItemCode changes. |
+| Transaction failure handling | Passed. Missing/duplicate/blank mapping failures do not create transfer records and do not move the source box. |
+
+## Full Barcode Suite Note
+
+The full `barcode` app test suite currently has unrelated failures in `BarcodeDispatchWorkflowTests` around dispatch SAP-sync expectations, and one run also hit a remote PostgreSQL connection timeout. These failures are outside the Intercompany Transfer item-code mapping change and occur in code paths not modified by this branch.


### PR DESCRIPTION
## Summary
- Add Jivo Oil to Jivo Mart item-code mapping for Barcode Intercompany Transfer.
- Resolve Jivo Mart destination ItemCode from OITM.U_Oil_ItemCode while preserving the original Oil ItemCode on transfer lines and reversal.
- Add regression tests and documentation for success, missing mapping, duplicate mapping, blank/null mapping, skipped routes, scan flow, and failure handling.

## Validation
- `$env:DEBUG='False'; .\.venv\Scripts\python.exe manage.py test barcode.tests.BarcodeWorkflowTests.test_oitm_item_service_looks_up_jivo_mart_item_by_oil_item_code barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_maps_destination_item_code barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_rejects_missing_item_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_rejects_duplicate_item_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_rejects_blank_or_null_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_item_mapping_is_skipped_for_other_company_pairs barcode.tests.BarcodeWorkflowTests.test_intercompany_oil_to_mart_scan_does_not_resolve_destination_mapping barcode.tests.BarcodeWorkflowTests.test_intercompany_scan_accepts_legacy_qr_payload_and_one_dimensional_value barcode.tests.BarcodeWorkflowTests.test_intercompany_transfer_api_end_to_end --keepdb` -> OK, 9 tests
- `$env:DEBUG='False'; .\.venv\Scripts\python.exe manage.py test barcode.tests.BarcodeWorkflowTests --keepdb` -> OK, 35 tests
- `$env:DEBUG='False'; .\.venv\Scripts\python.exe manage.py check` -> OK
- Frontend `http://127.0.0.1:5173/` -> 200 OK
- Backend admin `http://127.0.0.1:8000/admin/` -> 200 OK

## Notes
- The full `barcode` app suite has unrelated failures in `BarcodeDispatchWorkflowTests` around dispatch SAP-sync expectations, and one run hit a remote PostgreSQL timeout. Those paths were not changed by this branch.