### PR TITLE
Fix QC hold GRPO readiness

### DIFF
--- a/grpo/services.py
+++ b/grpo/services.py
@@ -42,6 +42,10 @@ class GRPOService:
     Service for handling GRPO operations.
     """
     SAP_DOCUMENT_COMMENTS_MAX_LENGTH = 254
+    QC_FINAL_STATUSES = frozenset({
+        InspectionStatus.ACCEPTED,
+        InspectionStatus.REJECTED,
+    })
     STATE_NAME_CODES = {
         "HARYANA": "HR",
         "DELHI": "DL",
@@ -921,9 +925,10 @@ class GRPOService:
     def get_pending_grpo_entries(self) -> List[VehicleEntry]:
         """
         Get all completed gate entries that are ready for GRPO posting.
-        Returns entries with status COMPLETED or QC_COMPLETED.
+        Returns entries with status COMPLETED or QC_COMPLETED, excluding stale
+        entries whose item QC is still HOLD/PENDING.
         """
-        return VehicleEntry.objects.filter(
+        entries = list(VehicleEntry.objects.filter(
             company__code=self.company_code,
             entry_type="RAW_MATERIAL",
             is_active=True,
@@ -931,8 +936,11 @@ class GRPOService:
         ).prefetch_related(
             "po_receipts",
             "po_receipts__items",
+            "po_receipts__items__arrival_slip",
+            "po_receipts__items__arrival_slip__inspection",
             "grpo_postings"
-        ).order_by("-entry_time")
+        ).order_by("-entry_time"))
+        return [entry for entry in entries if self.is_entry_ready_for_grpo(entry)]
 
     def get_grpo_dashboard_summary(self) -> Dict[str, Any]:
         """
@@ -1009,6 +1017,8 @@ class GRPOService:
         ).prefetch_related(
             "po_receipts",
             "po_receipts__items",
+            "po_receipts__items__arrival_slip",
+            "po_receipts__items__arrival_slip__inspection",
             "grpo_postings",
         ).order_by("-entry_time")
 
@@ -1037,10 +1047,7 @@ class GRPOService:
         except VehicleEntry.DoesNotExist:
             raise ValueError(f"Vehicle entry {vehicle_entry_id} not found")
 
-        is_ready = vehicle_entry.status in [
-            GateEntryStatus.COMPLETED,
-            GateEntryStatus.QC_COMPLETED
-        ]
+        is_ready = self.is_entry_ready_for_grpo(vehicle_entry)
 
         po_receipts_qs = vehicle_entry.po_receipts.all()
         if po_receipt_ids:
@@ -1118,6 +1125,78 @@ class GRPOService:
 
         inspection = arrival_slip.inspection
         return inspection.final_status
+
+    def _get_qc_blocking_reason(self, po_item_receipt: POItemReceipt) -> Optional[str]:
+        """
+        Return a QC status that blocks GRPO, if the item is still in QC flow.
+
+        Existing non-QC/legacy gate entries can still proceed when no arrival
+        slip exists. Once QC has started, the item must reach ACCEPTED or
+        REJECTED before GRPO can be listed or posted.
+        """
+        if not hasattr(po_item_receipt, "arrival_slip"):
+            return None
+
+        arrival_slip = po_item_receipt.arrival_slip
+        if not arrival_slip.is_submitted:
+            return "ARRIVAL_SLIP_PENDING"
+
+        if not hasattr(arrival_slip, "inspection"):
+            return "INSPECTION_PENDING"
+
+        inspection = arrival_slip.inspection
+        if inspection.final_status not in self.QC_FINAL_STATUSES:
+            return inspection.final_status or InspectionStatus.PENDING
+
+        return None
+
+    def _collect_qc_blockers(self, po_receipts: List[POReceipt]) -> List[str]:
+        blockers = []
+        for po_receipt in po_receipts:
+            for item in po_receipt.items.all():
+                status_value = self._get_qc_blocking_reason(item)
+                if not status_value:
+                    continue
+
+                report_no = ""
+                arrival_slip = getattr(item, "arrival_slip", None)
+                inspection = getattr(arrival_slip, "inspection", None) if arrival_slip else None
+                if inspection:
+                    report_no = f", report {inspection.report_no}"
+
+                blockers.append(
+                    f"PO {po_receipt.po_number}, item {item.po_item_code}"
+                    f"{report_no}, QC status {status_value}"
+                )
+
+        return blockers
+
+    def is_entry_ready_for_grpo(self, vehicle_entry: VehicleEntry) -> bool:
+        """Status plus item-level QC guard for GRPO readiness."""
+        if vehicle_entry.status not in [
+            GateEntryStatus.COMPLETED,
+            GateEntryStatus.QC_COMPLETED
+        ]:
+            return False
+
+        po_receipts = list(vehicle_entry.po_receipts.all())
+        return not self._collect_qc_blockers(po_receipts)
+
+    def _validate_qc_ready_for_grpo(self, vehicle_entry: VehicleEntry) -> None:
+        po_receipts = list(
+            POReceipt.objects.prefetch_related(
+                "items",
+                "items__arrival_slip",
+                "items__arrival_slip__inspection",
+            ).filter(vehicle_entry=vehicle_entry, is_active=True)
+        )
+        blockers = self._collect_qc_blockers(po_receipts)
+        if blockers:
+            raise ValueError(
+                "GRPO cannot be posted because QC is not final for one or more "
+                "related PO items: "
+                + "; ".join(blockers)
+            )
 
     def _build_structured_comments(
         self,
@@ -1234,6 +1313,8 @@ class GRPOService:
             raise ValueError(
                 f"Gate entry is not completed. Current status: {vehicle_entry.status}"
             )
+
+        self._validate_qc_ready_for_grpo(vehicle_entry)
 
         weighment = (
             Weighment.objects.select_for_update()

--- a/grpo/tests.py
+++ b/grpo/tests.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from django.urls import reverse
 from django.contrib.auth import get_user_model
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
 from rest_framework.test import APITestCase, APIClient
 from rest_framework import status
 
@@ -16,6 +17,9 @@ from dispatch_plans.models import DispatchPlan, DispatchPlanStatus
 from driver_management.models import VehicleEntry, Driver
 from vehicle_management.models import Transporter, Vehicle, VehicleType
 from raw_material_gatein.models import POReceipt, POItemReceipt
+from quality_control.enums import ArrivalSlipStatus, InspectionStatus, InspectionWorkflowStatus
+from quality_control.models import MaterialArrivalSlip, RawMaterialInspection
+from quality_control.services.rules import compute_entry_status
 from grpo.models import GRPOPosting, GRPOLinePosting, GRPOStatus, GRPOAttachment, SAPAttachmentStatus
 from grpo.serializers import ServiceGRPOPostRequestSerializer, ServiceGRPOPreviewSerializer
 from grpo.services import GRPOService
@@ -220,6 +224,39 @@ class GRPOServiceTests(TestCase):
             uom="KG"
         )
 
+    def _attach_qc_inspection(
+        self,
+        po_item,
+        final_status=InspectionStatus.ACCEPTED,
+        workflow_status=InspectionWorkflowStatus.QAM_APPROVED,
+        report_no="RPT-GRPO-QC-001",
+    ):
+        arrival_slip = MaterialArrivalSlip.objects.create(
+            po_item_receipt=po_item,
+            particulars=po_item.item_name,
+            arrival_datetime=timezone.now(),
+            party_name=po_item.po_receipt.supplier_name,
+            billing_qty=po_item.received_qty,
+            billing_uom=po_item.uom,
+            truck_no_as_per_bill=po_item.po_receipt.vehicle_entry.vehicle.vehicle_number,
+            status=ArrivalSlipStatus.SUBMITTED,
+            is_submitted=True,
+            submitted_at=timezone.now(),
+            submitted_by=self.user,
+        )
+        return RawMaterialInspection.objects.create(
+            arrival_slip=arrival_slip,
+            report_no=report_no,
+            internal_lot_no=f"LOT-{report_no}",
+            inspection_date=timezone.now().date(),
+            description_of_material=po_item.item_name,
+            sap_code=po_item.po_item_code,
+            supplier_name=po_item.po_receipt.supplier_name,
+            purchase_order_no=po_item.po_receipt.po_number,
+            final_status=final_status,
+            workflow_status=workflow_status,
+        )
+
     def test_get_pending_grpo_entries(self):
         """Test fetching pending GRPO entries"""
         service = GRPOService(company_code="TC001")
@@ -227,6 +264,131 @@ class GRPOServiceTests(TestCase):
 
         self.assertEqual(len(entries), 1)
         self.assertEqual(entries[0].entry_no, "VE-2024-001")
+
+    def test_qam_approved_hold_does_not_complete_qc(self):
+        """QAM approval with HOLD final status remains in QC flow."""
+        self.vehicle_entry.status = GateEntryStatus.QC_COMPLETED
+        self.vehicle_entry.save(update_fields=["status"])
+        self._attach_qc_inspection(
+            self.po_item,
+            final_status=InspectionStatus.HOLD,
+            workflow_status=InspectionWorkflowStatus.QAM_APPROVED,
+            report_no="RPT-20260606-0002",
+        )
+
+        self.assertEqual(
+            compute_entry_status(self.vehicle_entry),
+            GateEntryStatus.QC_AWAITING_QAM,
+        )
+
+    def test_pending_grpo_entries_exclude_qam_approved_hold_qc(self):
+        """Stale QC_COMPLETED entries are hidden while an item is HOLD."""
+        self.vehicle_entry.status = GateEntryStatus.QC_COMPLETED
+        self.vehicle_entry.save(update_fields=["status"])
+        self._attach_qc_inspection(
+            self.po_item,
+            final_status=InspectionStatus.HOLD,
+            workflow_status=InspectionWorkflowStatus.QAM_APPROVED,
+            report_no="RPT-20260606-0002",
+        )
+
+        service = GRPOService(company_code="TC001")
+        entry_numbers = [entry.entry_no for entry in service.get_pending_grpo_entries()]
+        preview = service.get_grpo_preview_data(self.vehicle_entry.id)
+
+        self.assertNotIn("VE-2024-001", entry_numbers)
+        self.assertFalse(preview[0]["is_ready_for_grpo"])
+        self.assertEqual(preview[0]["items"][0]["qc_status"], InspectionStatus.HOLD)
+
+    def test_pending_grpo_entries_allow_final_accepted_qc(self):
+        """QAM approval proceeds only after the final QC decision is ACCEPTED."""
+        self.vehicle_entry.status = GateEntryStatus.QC_COMPLETED
+        self.vehicle_entry.save(update_fields=["status"])
+        self._attach_qc_inspection(
+            self.po_item,
+            final_status=InspectionStatus.ACCEPTED,
+            workflow_status=InspectionWorkflowStatus.QAM_APPROVED,
+            report_no="RPT-GRPO-QC-ACCEPTED",
+        )
+
+        service = GRPOService(company_code="TC001")
+        entry_numbers = [entry.entry_no for entry in service.get_pending_grpo_entries()]
+
+        self.assertIn("VE-2024-001", entry_numbers)
+        self.assertEqual(compute_entry_status(self.vehicle_entry), GateEntryStatus.QC_COMPLETED)
+
+    def test_post_grpo_rejects_stale_qc_completed_with_hold_item(self):
+        """Posting cannot create partial GRPO rows while any related item is HOLD."""
+        self.vehicle_entry.status = GateEntryStatus.QC_COMPLETED
+        self.vehicle_entry.save(update_fields=["status"])
+        self._attach_qc_inspection(
+            self.po_item,
+            final_status=InspectionStatus.HOLD,
+            workflow_status=InspectionWorkflowStatus.QAM_APPROVED,
+            report_no="RPT-20260606-0002",
+        )
+
+        service = GRPOService(company_code="TC001")
+        before_count = GRPOPosting.objects.count()
+
+        with self.assertRaisesMessage(ValueError, "QC is not final"):
+            service.post_grpo(
+                vehicle_entry_id=self.vehicle_entry.id,
+                po_receipt_ids=[self.po_receipt.id],
+                user=self.user,
+                items=[{
+                    "po_item_receipt_id": self.po_item.id,
+                    "accepted_qty": Decimal("95.000"),
+                }],
+                branch_id=1,
+            )
+
+        self.assertEqual(GRPOPosting.objects.count(), before_count)
+
+    def test_post_grpo_rejects_when_related_unselected_po_item_is_hold(self):
+        """Related HOLD QC items block posting even when their PO is not selected."""
+        self.vehicle_entry.status = GateEntryStatus.QC_COMPLETED
+        self.vehicle_entry.save(update_fields=["status"])
+        related_po = POReceipt.objects.create(
+            vehicle_entry=self.vehicle_entry,
+            po_number="PO-RELATED-HOLD",
+            supplier_code="SUP001",
+            supplier_name="Test Supplier",
+            sap_doc_entry=54321,
+            branch_id=1,
+        )
+        related_item = POItemReceipt.objects.create(
+            po_receipt=related_po,
+            po_item_code="ITEM-HOLD",
+            item_name="Related Hold Item",
+            ordered_qty=Decimal("10.000"),
+            received_qty=Decimal("10.000"),
+            accepted_qty=Decimal("10.000"),
+            rejected_qty=Decimal("0.000"),
+            sap_line_num=0,
+            unit_price=Decimal("10.000000"),
+            uom="KG",
+        )
+        self._attach_qc_inspection(
+            related_item,
+            final_status=InspectionStatus.HOLD,
+            workflow_status=InspectionWorkflowStatus.QAM_APPROVED,
+            report_no="RPT-GRPO-QC-RELATED-HOLD",
+        )
+
+        service = GRPOService(company_code="TC001")
+
+        with self.assertRaisesMessage(ValueError, "PO PO-RELATED-HOLD"):
+            service.post_grpo(
+                vehicle_entry_id=self.vehicle_entry.id,
+                po_receipt_ids=[self.po_receipt.id],
+                user=self.user,
+                items=[{
+                    "po_item_receipt_id": self.po_item.id,
+                    "accepted_qty": Decimal("95.000"),
+                }],
+                branch_id=1,
+            )
 
     def test_inactive_gate_entries_are_hidden_from_grpo(self):
         """Soft-deleted gate entries should not appear in material GRPO surfaces."""

--- a/grpo/views.py
+++ b/grpo/views.py
@@ -65,7 +65,7 @@ class AllGRPOEntriesListAPI(APIView):
 
     def get(self, request):
         from collections import defaultdict
-        from gate_core.enums import GateEntryStatus, GRPO_READY_STATUSES, get_entry_phase
+        from gate_core.enums import GateEntryStatus, get_entry_phase
 
         service = GRPOService(company_code=request.company.company.code)
         entries = service.get_all_grpo_visible_entries()
@@ -107,7 +107,7 @@ class AllGRPOEntriesListAPI(APIView):
                 "status": entry.status,
                 "status_label": status_labels.get(entry.status, entry.status),
                 "phase": get_entry_phase(entry.status),
-                "is_ready_for_grpo": entry.status in GRPO_READY_STATUSES,
+                "is_ready_for_grpo": service.is_entry_ready_for_grpo(entry),
                 "is_fully_posted": total_count > 0 and pending_count == 0,
                 "entry_time": entry.entry_time,
                 "total_po_count": total_count,

--- a/quality_control/services/rules.py
+++ b/quality_control/services/rules.py
@@ -54,8 +54,10 @@ def compute_entry_status(vehicle_entry):
     """
     from gate_core.enums import GateEntryStatus
 
-    # Collect workflow statuses of all inspections
+    # Collect workflow and final statuses of all inspections. QAM approval
+    # alone is not enough to complete QC; the item needs a final decision.
     statuses = []
+    final_statuses = []
     has_items = False
 
     for po in vehicle_entry.po_receipts.all():
@@ -70,19 +72,22 @@ def compute_entry_status(vehicle_entry):
                 return GateEntryStatus.QC_PENDING
 
             statuses.append(inspection.workflow_status)
+            final_statuses.append(inspection.final_status)
 
     if not has_items:
         return vehicle_entry.status  # no change
 
-    # Terminal statuses (QAM_APPROVED or REJECTED)
-    terminal = {InspectionWorkflowStatus.QAM_APPROVED, InspectionWorkflowStatus.REJECTED}
+    final_decisions = {InspectionStatus.ACCEPTED, InspectionStatus.REJECTED}
 
     # If ALL items are terminal → QC_COMPLETED
-    if all(s in terminal for s in statuses):
+    if all(s in final_decisions for s in final_statuses):
         return GateEntryStatus.QC_COMPLETED
 
     # If ANY item is rejected but others aren't done → QC_REJECTED
-    if InspectionWorkflowStatus.REJECTED in statuses:
+    if (
+        InspectionWorkflowStatus.REJECTED in statuses
+        or InspectionStatus.REJECTED in final_statuses
+    ):
         return GateEntryStatus.QC_REJECTED
 
     # Otherwise, find the highest stage any item has reached


### PR DESCRIPTION
## Summary
- Fix QC status calculation so QAM approval only completes QC after final_status is ACCEPTED or REJECTED
- Exclude HOLD/PENDING QC items from GRPO pending/readiness surfaces
- Reject GRPO posting when any related PO item still has non-final QC status
- Add regression tests for stale QC_COMPLETED plus HOLD inspection state

## Root cause
GRPO readiness relied on gate entry status, while QC completion could be computed from workflow_status=QAM_APPROVED even when final_status was HOLD.

## Validation
- DEBUG=False .venv/Scripts/python.exe manage.py check
- DEBUG=False .venv/Scripts/python.exe manage.py test grpo --keepdb -v 1
- .venv/Scripts/python.exe -m py_compile quality_control/services/rules.py grpo/services.py grpo/views.py grpo/tests.py