### PR TITLE
feat(dispatch-plans): lock vehicle link after empty-in; empty-out resets the flow

### DIFF
--- a/dispatch_plans/serializers.py
+++ b/dispatch_plans/serializers.py
@@ -139,11 +139,21 @@ class DispatchPlanSerializer(serializers.ModelSerializer):
     transporter_id = serializers.IntegerField(read_only=True, allow_null=True)
     driver_id = serializers.IntegerField(read_only=True, allow_null=True)
     linked_vehicle_entry_id = serializers.IntegerField(read_only=True, allow_null=True)
+    is_vehicle_link_locked = serializers.SerializerMethodField()
     effective_month = serializers.DateField(
         allow_null=True,
         format="%Y-%m",
         read_only=True,
     )
+
+    def get_is_vehicle_link_locked(self, obj) -> bool:
+        """True once the empty vehicle gate-in is completed for this plan.
+
+        At that point the vehicle has physically arrived and is ready to dock,
+        so the vehicle linking can no longer be edited or unlinked.
+        """
+        entry = obj.linked_vehicle_entry
+        return bool(entry and entry.status == "COMPLETED")
 
     class Meta:
         model = DispatchPlan
@@ -168,6 +178,7 @@ class DispatchPlanSerializer(serializers.ModelSerializer):
             "transporter_id",
             "driver_id",
             "linked_vehicle_entry_id",
+            "is_vehicle_link_locked",
             "booking_status",
             "dispatch_date",
             "priority",

--- a/dispatch_plans/services.py
+++ b/dispatch_plans/services.py
@@ -98,6 +98,17 @@ def compute_pipeline_stage(plan):
 
 
 class DispatchPlansService:
+    # Transport-identity fields frozen once the empty vehicle gate-in is
+    # completed (the vehicle has physically arrived and is ready to dock).
+    # Other plan fields (bilty, freight, remarks) stay editable.
+    LINK_LOCK_GUARDED_FIELDS = (
+        "vehicle_id",
+        "transporter_id",
+        "driver_id",
+        "linked_vehicle_entry_id",
+        "booking_status",
+    )
+
     def __init__(self, company_code: str):
         self.company_code = company_code
         self.company = Company.objects.get(code=company_code)
@@ -113,7 +124,7 @@ class DispatchPlansService:
                 company=self.company,
                 sap_invoice_doc_entry__in=doc_entries,
                 is_active=True,
-            )
+            ).select_related("linked_vehicle_entry")
         }
 
         data = []
@@ -159,7 +170,7 @@ class DispatchPlansService:
             company=self.company,
             sap_invoice_doc_entry=bill["doc_entry"],
             is_active=True,
-        ).first()
+        ).select_related("linked_vehicle_entry").first()
         bill["plan"] = (
             DispatchPlanSerializer(plan).data
             if plan
@@ -287,6 +298,7 @@ class DispatchPlansService:
     ) -> DispatchPlan:
         doc_num = data.pop("sap_invoice_doc_num", "")
         bilty_attachment = data.get("bilty_attachment")
+        self._assert_link_not_locked(sap_invoice_doc_entry, data)
         self._validate_links(data)
         self._apply_master_data(data)
         plan, created = DispatchPlan.objects.get_or_create(
@@ -436,6 +448,7 @@ class DispatchPlansService:
             "transporter_id": None,
             "driver_id": None,
             "linked_vehicle_entry_id": None,
+            "is_vehicle_link_locked": False,
             "booking_status": DispatchPlanStatus.PENDING,
             "dispatch_date": None,
             "priority": "",
@@ -517,6 +530,42 @@ class DispatchPlansService:
         normalized = str(value or "").upper().replace("_", " ")
         normalized = " ".join(normalized.split())
         return "JIVO MART" in normalized or "JIVOMART" in normalized
+
+    def _assert_link_not_locked(
+        self,
+        sap_invoice_doc_entry: int,
+        data: Dict[str, Any],
+    ) -> None:
+        """Freeze the transport assignment once the empty vehicle gate-in is done.
+
+        When the linked gate ``VehicleEntry`` is COMPLETED the empty vehicle has
+        physically arrived and is ready to dock, so the vehicle/transporter/driver
+        link must not be re-pointed (or the booking un-done). Compares the caller's
+        explicit fields against the stored plan; unchanged values pass through so
+        unrelated edits (bilty, freight, remarks) still work.
+        """
+        existing = (
+            DispatchPlan.objects.select_related("linked_vehicle_entry")
+            .filter(
+                company=self.company,
+                sap_invoice_doc_entry=sap_invoice_doc_entry,
+            )
+            .first()
+        )
+        if existing is None:
+            return
+
+        entry = existing.linked_vehicle_entry
+        if entry is None or entry.status != "COMPLETED":
+            return
+
+        for field in self.LINK_LOCK_GUARDED_FIELDS:
+            if field in data and data[field] != getattr(existing, field):
+                raise ValueError(
+                    "Vehicle linking is locked: the empty vehicle gate-in is "
+                    "already completed for this vehicle, so the linking can no "
+                    "longer be changed."
+                )
 
     def _validate_links(self, data: Dict[str, Any]) -> None:
         vehicle_id = data.get("vehicle_id")

--- a/dispatch_plans/tests.py
+++ b/dispatch_plans/tests.py
@@ -8,7 +8,11 @@ from gate_core.enums import GateEntryStatus
 from vehicle_management.models import Transporter, Vehicle, VehicleType
 
 from .models import DispatchPlan
-from .serializers import DispatchBillFilterSerializer, DispatchPlanUpdateSerializer
+from .serializers import (
+    DispatchBillFilterSerializer,
+    DispatchPlanSerializer,
+    DispatchPlanUpdateSerializer,
+)
 from .services import DispatchPlansService
 
 User = get_user_model()
@@ -192,3 +196,103 @@ class DispatchPlanLinkedVehicleEntryTests(TestCase):
         self.assertEqual(plan.contact_person, "Arnav Contact")
         self.assertEqual(plan.mobile_no, "9811111111")
         self.assertEqual(DispatchPlan.objects.count(), 1)
+
+    def _booked_plan_with_completed_entry(self):
+        self.vehicle_entry.status = GateEntryStatus.COMPLETED
+        self.vehicle_entry.save(update_fields=["status"])
+        return DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=626050517,
+            sap_invoice_doc_num="626050517",
+            booking_status="BOOKED",
+            vehicle=self.vehicle,
+            transporter=self.transporter,
+            driver=self.driver,
+            linked_vehicle_entry=self.vehicle_entry,
+        )
+
+    def test_relink_blocked_once_empty_vehicle_in_completed(self):
+        self._booked_plan_with_completed_entry()
+        other_vehicle = Vehicle.objects.create(
+            vehicle_number="HR55ZZ9999",
+            vehicle_type=self.vehicle.vehicle_type,
+            transporter=self.transporter,
+        )
+        service = DispatchPlansService(company_code=self.company.code)
+
+        with self.assertRaises(ValueError):
+            service.update_plan(
+                sap_invoice_doc_entry=626050517,
+                data={"vehicle_id": other_vehicle.id},
+                user=self.user,
+            )
+
+        plan = DispatchPlan.objects.get(sap_invoice_doc_entry=626050517)
+        self.assertEqual(plan.vehicle_id, self.vehicle.id)
+
+    def test_unlink_blocked_once_empty_vehicle_in_completed(self):
+        self._booked_plan_with_completed_entry()
+        service = DispatchPlansService(company_code=self.company.code)
+
+        with self.assertRaises(ValueError):
+            service.update_plan(
+                sap_invoice_doc_entry=626050517,
+                data={
+                    "vehicle_id": None,
+                    "transporter_id": None,
+                    "driver_id": None,
+                    "linked_vehicle_entry_id": None,
+                    "booking_status": "PENDING",
+                },
+                user=self.user,
+            )
+
+    def test_unrelated_edit_allowed_once_empty_vehicle_in_completed(self):
+        self._booked_plan_with_completed_entry()
+        service = DispatchPlansService(company_code=self.company.code)
+
+        plan = service.update_plan(
+            sap_invoice_doc_entry=626050517,
+            data={"remarks": "Reached dock 2"},
+            user=self.user,
+        )
+
+        self.assertEqual(plan.remarks, "Reached dock 2")
+        self.assertEqual(plan.vehicle_id, self.vehicle.id)
+
+    def test_unlink_allowed_before_empty_vehicle_in_completed(self):
+        DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=626050517,
+            sap_invoice_doc_num="626050517",
+            booking_status="BOOKED",
+            vehicle=self.vehicle,
+            transporter=self.transporter,
+            driver=self.driver,
+        )
+        service = DispatchPlansService(company_code=self.company.code)
+
+        plan = service.update_plan(
+            sap_invoice_doc_entry=626050517,
+            data={
+                "vehicle_id": None,
+                "transporter_id": None,
+                "driver_id": None,
+                "linked_vehicle_entry_id": None,
+                "booking_status": "PENDING",
+            },
+            user=self.user,
+        )
+
+        self.assertIsNone(plan.vehicle_id)
+        self.assertEqual(plan.booking_status, "PENDING")
+        self.assertEqual(plan.vehicle_no, "")
+
+    def test_serializer_flags_locked_link_when_entry_completed(self):
+        plan = self._booked_plan_with_completed_entry()
+        plan = (
+            DispatchPlan.objects.select_related("linked_vehicle_entry")
+            .get(pk=plan.pk)
+        )
+
+        self.assertTrue(DispatchPlanSerializer(plan).data["is_vehicle_link_locked"])

--- a/gate_core/serializers.py
+++ b/gate_core/serializers.py
@@ -628,6 +628,15 @@ class EmptyVehicleEligibleEntrySerializer(serializers.Serializer):
     driver_name = serializers.CharField(source="driver.name")
     driver_mobile = serializers.CharField(source="driver.mobile_no")
     remarks = serializers.CharField()
+    # Side effects of marking this vehicle out empty (computed by the view).
+    release_invoice_count = serializers.SerializerMethodField()
+    release_cancels_docking = serializers.SerializerMethodField()
+
+    def get_release_invoice_count(self, obj) -> int:
+        return getattr(obj, "release_invoice_count", 0)
+
+    def get_release_cancels_docking(self, obj) -> bool:
+        return getattr(obj, "release_cancels_docking", False)
 
 
 class EmptyVehicleGateOutSerializer(serializers.ModelSerializer):

--- a/gate_core/tests.py
+++ b/gate_core/tests.py
@@ -104,6 +104,216 @@ class SalesDispatchAPITests(APITestCase):
         )
         return user
 
+    def test_empty_vehicle_out_release_undoes_empty_in_keeps_booking(self):
+        from gate_core.views import release_dispatch_plans_for_empty_out
+
+        vehicle_entry = VehicleEntry.objects.create(
+            entry_no="EVGO-REL-1",
+            company=self.company,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            entry_type="EMPTY_VEHICLE",
+            status="COMPLETED",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        booked = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=90001,
+            sap_invoice_doc_num="90001",
+            booking_status=DispatchPlanStatus.BOOKED,
+            vehicle=self.vehicle,
+            transporter=self.transporter,
+            driver=self.driver,
+            linked_vehicle_entry=vehicle_entry,
+            vehicle_no=self.vehicle.vehicle_number,
+            transporter_name=self.transporter.name,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        released = release_dispatch_plans_for_empty_out(vehicle_entry, self.user)
+
+        self.assertEqual(released, 1)
+        booked.refresh_from_db()
+        # Empty-in is undone (link cleared, unlocks editing) but the booking and
+        # vehicle assignment are preserved so the flow can start again.
+        self.assertIsNone(booked.linked_vehicle_entry_id)
+        self.assertEqual(booked.booking_status, DispatchPlanStatus.BOOKED)
+        self.assertEqual(booked.vehicle_id, self.vehicle.id)
+        self.assertEqual(booked.vehicle_no, self.vehicle.vehicle_number)
+        self.assertEqual(booked.transporter_name, self.transporter.name)
+
+    def test_empty_vehicle_out_release_cancels_unscanned_docking_gate_out(self):
+        from gate_core.views import release_dispatch_plans_for_empty_out
+
+        empty_entry = VehicleEntry.objects.create(
+            entry_no="EVGO-REL-3",
+            company=self.company,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            entry_type="EMPTY_VEHICLE",
+            status="COMPLETED",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        plan = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=90003,
+            sap_invoice_doc_num="90003",
+            booking_status=DispatchPlanStatus.BOOKED,
+            vehicle=self.vehicle,
+            linked_vehicle_entry=empty_entry,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        # Vehicle moved to docking (separate SALES_DISPATCH entry) but no scans.
+        gate_out = self.create_sales_dispatch(
+            "93",
+            status_value=SalesDispatchGateOutStatus.DOCKED,
+            dispatch_plan=plan,
+        )
+
+        release_dispatch_plans_for_empty_out(empty_entry, self.user)
+
+        gate_out.refresh_from_db()
+        gate_out.vehicle_entry.refresh_from_db()
+        plan.refresh_from_db()
+        self.assertEqual(gate_out.status, SalesDispatchGateOutStatus.CANCELLED)
+        self.assertEqual(gate_out.vehicle_entry.status, "CANCELLED")
+        self.assertIsNone(plan.linked_vehicle_entry_id)
+        self.assertEqual(plan.booking_status, DispatchPlanStatus.BOOKED)
+
+    def test_empty_out_release_preview_reports_side_effects(self):
+        from gate_core.views import empty_out_release_preview
+
+        empty_entry = VehicleEntry.objects.create(
+            entry_no="EVGO-PRE-1",
+            company=self.company,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            entry_type="EMPTY_VEHICLE",
+            status="COMPLETED",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        plan = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=90005,
+            sap_invoice_doc_num="90005",
+            booking_status=DispatchPlanStatus.BOOKED,
+            vehicle=self.vehicle,
+            linked_vehicle_entry=empty_entry,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        self.create_sales_dispatch(
+            "95",
+            status_value=SalesDispatchGateOutStatus.DOCKED,
+            dispatch_plan=plan,
+        )
+
+        empty_out_release_preview(self.company, [empty_entry])
+
+        self.assertEqual(empty_entry.release_invoice_count, 1)
+        self.assertTrue(empty_entry.release_cancels_docking)
+
+    def test_empty_out_release_preview_without_docking(self):
+        from gate_core.views import empty_out_release_preview
+
+        empty_entry = VehicleEntry.objects.create(
+            entry_no="EVGO-PRE-2",
+            company=self.company,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            entry_type="EMPTY_VEHICLE",
+            status="COMPLETED",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=90006,
+            sap_invoice_doc_num="90006",
+            booking_status=DispatchPlanStatus.BOOKED,
+            vehicle=self.vehicle,
+            linked_vehicle_entry=empty_entry,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        empty_out_release_preview(self.company, [empty_entry])
+
+        self.assertEqual(empty_entry.release_invoice_count, 1)
+        self.assertFalse(empty_entry.release_cancels_docking)
+
+    def test_empty_vehicle_out_release_keeps_scanned_docking_gate_out(self):
+        from gate_core.views import release_dispatch_plans_for_empty_out
+
+        empty_entry = VehicleEntry.objects.create(
+            entry_no="EVGO-REL-4",
+            company=self.company,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            entry_type="EMPTY_VEHICLE",
+            status="COMPLETED",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        plan = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=90004,
+            sap_invoice_doc_num="90004",
+            booking_status=DispatchPlanStatus.BOOKED,
+            vehicle=self.vehicle,
+            linked_vehicle_entry=empty_entry,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        gate_out = self.create_sales_dispatch(
+            "94",
+            status_value=SalesDispatchGateOutStatus.DOCKED,
+            dispatch_plan=plan,
+        )
+        self.create_box_scan(gate_out, "94")
+
+        release_dispatch_plans_for_empty_out(empty_entry, self.user)
+
+        gate_out.refresh_from_db()
+        # A scanned gate-out is committed to loading and must not be cancelled.
+        self.assertEqual(gate_out.status, SalesDispatchGateOutStatus.DOCKED)
+
+    def test_empty_vehicle_out_release_leaves_dispatched_plans_untouched(self):
+        from gate_core.views import release_dispatch_plans_for_empty_out
+
+        vehicle_entry = VehicleEntry.objects.create(
+            entry_no="EVGO-REL-2",
+            company=self.company,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            entry_type="EMPTY_VEHICLE",
+            status="COMPLETED",
+            created_by=self.user,
+            updated_by=self.user,
+        )
+        dispatched = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=90002,
+            sap_invoice_doc_num="90002",
+            booking_status=DispatchPlanStatus.DISPATCHED,
+            vehicle=self.vehicle,
+            linked_vehicle_entry=vehicle_entry,
+            created_by=self.user,
+            updated_by=self.user,
+        )
+
+        released = release_dispatch_plans_for_empty_out(vehicle_entry, self.user)
+
+        self.assertEqual(released, 0)
+        dispatched.refresh_from_db()
+        self.assertEqual(dispatched.linked_vehicle_entry_id, vehicle_entry.id)
+        self.assertEqual(dispatched.booking_status, DispatchPlanStatus.DISPATCHED)
+
     def sap_document(
         self,
         doc_entry,

--- a/gate_core/views.py
+++ b/gate_core/views.py
@@ -2,6 +2,7 @@ import datetime as dt
 from decimal import Decimal, InvalidOperation
 
 from django.db import transaction
+from django.db.models import Count
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.utils.dateparse import parse_date
@@ -41,6 +42,7 @@ from .models import (
     JobWorkGateInItem,
     RejectedQCReturnEntry,
     RejectedQCReturnItem,
+    SalesDispatchBoxScan,
     SalesDispatchDocumentType,
     SalesDispatchGateOut,
     SalesDispatchGateOutItem,
@@ -2522,6 +2524,21 @@ class EmptyVehicleEligibleEntriesView(APIView):
         ).values("vehicle_entry_id")
         qs = qs.exclude(id__in=completed_gate_out_entry_ids)
 
+        # A dispatch vehicle stays eligible to leave empty until box scanning
+        # starts at docking. Once any box is scanned against a plan linked to
+        # this entry, the vehicle is committed to loading and no longer eligible.
+        scanned_entry_ids = (
+            SalesDispatchBoxScan.objects.filter(
+                is_active=True,
+                sales_dispatch__dispatch_plan__linked_vehicle_entry__isnull=False,
+            )
+            .values_list(
+                "sales_dispatch__dispatch_plan__linked_vehicle_entry_id",
+                flat=True,
+            )
+        )
+        qs = qs.exclude(id__in=scanned_entry_ids)
+
         entry_type = request.query_params.get("entry_type")
         from_date = request.query_params.get("from_date")
         to_date = request.query_params.get("to_date")
@@ -2533,8 +2550,121 @@ class EmptyVehicleEligibleEntriesView(APIView):
         if to_date:
             qs = qs.filter(entry_time__date__lte=to_date)
 
-        serializer = EmptyVehicleEligibleEntrySerializer(qs, many=True)
+        entries = list(qs)
+        empty_out_release_preview(request.company.company, entries)
+        serializer = EmptyVehicleEligibleEntrySerializer(entries, many=True)
         return Response(serializer.data)
+
+
+# Docking gate-out statuses that are past the point an empty-out should unwind.
+_EMPTY_OUT_FINALIZED_GATE_OUT_STATUSES = (
+    SalesDispatchGateOutStatus.PRINT_COMMITTED,
+    SalesDispatchGateOutStatus.DISPATCHED,
+    SalesDispatchGateOutStatus.REJECTED,
+    SalesDispatchGateOutStatus.CANCELLED,
+)
+
+
+def empty_out_release_preview(company, entries):
+    """Annotate eligible empty-out entries with the side effects of marking out.
+
+    Sets ``release_invoice_count`` (booked invoices that would be released) and
+    ``release_cancels_docking`` (whether an un-scanned docking gate-out would be
+    cancelled) on each entry, computed in bulk to avoid per-entry queries.
+    """
+    entry_ids = [entry.id for entry in entries]
+    if not entry_ids:
+        return
+
+    invoice_counts = dict(
+        DispatchPlan.objects.filter(
+            company=company,
+            is_active=True,
+            linked_vehicle_entry_id__in=entry_ids,
+            booking_status=DispatchPlanStatus.BOOKED,
+        )
+        .values_list("linked_vehicle_entry_id")
+        .annotate(count=Count("id"))
+    )
+    docking_entry_ids = set(
+        SalesDispatchGateOut.objects.filter(
+            company=company,
+            is_active=True,
+            dispatch_plan__linked_vehicle_entry_id__in=entry_ids,
+        )
+        .exclude(status__in=_EMPTY_OUT_FINALIZED_GATE_OUT_STATUSES)
+        .exclude(box_scans__is_active=True)
+        .values_list("dispatch_plan__linked_vehicle_entry_id", flat=True)
+    )
+    for entry in entries:
+        entry.release_invoice_count = invoice_counts.get(entry.id, 0)
+        entry.release_cancels_docking = entry.id in docking_entry_ids
+
+
+def release_dispatch_plans_for_empty_out(vehicle_entry, user):
+    """Undo the empty vehicle gate-in when the vehicle leaves empty.
+
+    Treats the empty-in as if it never happened so the flow can start again: the
+    plans booked to this entry keep their vehicle booking (still ``BOOKED``) but
+    the ``linked_vehicle_entry`` is cleared. That unlocks vehicle-linking edits
+    (the lock keys on a COMPLETED ``linked_vehicle_entry``) and lets a fresh
+    empty-in re-match. Any un-scanned docking gate-out created for those plans is
+    cancelled too, so the pipeline resets fully. Returns the number of plans
+    released.
+    """
+    now = timezone.now()
+    plan_ids = list(
+        DispatchPlan.objects.filter(
+            company=vehicle_entry.company,
+            is_active=True,
+            linked_vehicle_entry=vehicle_entry,
+            booking_status=DispatchPlanStatus.BOOKED,
+        ).values_list("id", flat=True)
+    )
+    if not plan_ids:
+        return 0
+
+    # Cancel any docking gate-out for these plans that has not begun scanning.
+    # Scanned vehicles are excluded from empty-out eligibility, so this only
+    # unwinds the "docked but not loaded" state.
+    gate_outs = (
+        SalesDispatchGateOut.objects.filter(
+            company=vehicle_entry.company,
+            is_active=True,
+            dispatch_plan_id__in=plan_ids,
+        )
+        .exclude(status__in=_EMPTY_OUT_FINALIZED_GATE_OUT_STATUSES)
+        .exclude(box_scans__is_active=True)
+        .select_related("vehicle_entry")
+        .distinct()
+    )
+    for gate_out in gate_outs:
+        gate_out.status = SalesDispatchGateOutStatus.CANCELLED
+        gate_out.cancel_reason = "Vehicle left empty before loading (empty vehicle out)."
+        gate_out.cancelled_by = user
+        gate_out.cancelled_at = now
+        gate_out.updated_by = user
+        gate_out.save(
+            update_fields=[
+                "status",
+                "cancel_reason",
+                "cancelled_by",
+                "cancelled_at",
+                "updated_by",
+                "updated_at",
+            ]
+        )
+        dock_entry = gate_out.vehicle_entry
+        if dock_entry is not None:
+            dock_entry.status = "CANCELLED"
+            dock_entry.updated_by = user
+            dock_entry.save(update_fields=["status", "updated_by", "updated_at"])
+
+    return DispatchPlan.objects.filter(id__in=plan_ids).update(
+        linked_vehicle_entry=None,
+        updated_by=user,
+        updated_at=now,
+    )
 
 
 class EmptyVehicleGateOutListCreateView(APIView):
@@ -2604,19 +2734,23 @@ class EmptyVehicleGateOutListCreateView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        gate_out = EmptyVehicleGateOut.objects.create(
-            company=request.company.company,
-            entry_no=EmptyVehicleGateOut.generate_entry_no(),
-            vehicle_entry=vehicle_entry,
-            vehicle=vehicle_entry.vehicle,
-            driver=vehicle_entry.driver,
-            gate_out_date=data["gate_out_date"],
-            out_time=data["out_time"],
-            security_name=data.get("security_name", ""),
-            remarks=data.get("remarks", ""),
-            created_by=request.user,
-            updated_by=request.user,
-        )
+        with transaction.atomic():
+            gate_out = EmptyVehicleGateOut.objects.create(
+                company=request.company.company,
+                entry_no=EmptyVehicleGateOut.generate_entry_no(),
+                vehicle_entry=vehicle_entry,
+                vehicle=vehicle_entry.vehicle,
+                driver=vehicle_entry.driver,
+                gate_out_date=data["gate_out_date"],
+                out_time=data["out_time"],
+                security_name=data.get("security_name", ""),
+                remarks=data.get("remarks", ""),
+                created_by=request.user,
+                updated_by=request.user,
+            )
+            # The vehicle leaves empty, so release any invoices booked to it
+            # back to PENDING and unlink them for re-planning.
+            release_dispatch_plans_for_empty_out(vehicle_entry, request.user)
 
         return Response(
             EmptyVehicleGateOutSerializer(gate_out).data,


### PR DESCRIPTION
Companion to FactoryFlow PR (same branch) - merge together. Freeze transport assignment once linked empty-vehicle-in is COMPLETED; empty-out undoes the empty-in (clears link, keeps booking) and auto-cancels un-scanned docking gate-out; empty-out eligibility keeps a docked vehicle listed until box scanning starts; eligible-entries reports side effects. 51 tests pass (11 new).