### PR TITLE
fix(dispatch-plans): handle dict in is_vehicle_link_locked (500 on bills endpoint)

### DIFF
--- a/dispatch_plans/serializers.py
+++ b/dispatch_plans/serializers.py
@@ -150,8 +150,12 @@ class DispatchPlanSerializer(serializers.ModelSerializer):
         """True once the empty vehicle gate-in is completed for this plan.
 
         At that point the vehicle has physically arrived and is ready to dock,
-        so the vehicle linking can no longer be edited or unlinked.
+        so the vehicle linking can no longer be edited or unlinked. ``obj`` is a
+        model instance on first serialization, but a plain dict when a bill row's
+        already-serialized plan is re-serialized via ``DispatchBillSerializer``.
         """
+        if isinstance(obj, dict):
+            return bool(obj.get("is_vehicle_link_locked", False))
         entry = obj.linked_vehicle_entry
         return bool(entry and entry.status == "COMPLETED")
 

--- a/dispatch_plans/tests.py
+++ b/dispatch_plans/tests.py
@@ -296,3 +296,22 @@ class DispatchPlanLinkedVehicleEntryTests(TestCase):
         )
 
         self.assertTrue(DispatchPlanSerializer(plan).data["is_vehicle_link_locked"])
+
+    def test_link_locked_method_handles_model_and_dict(self):
+        # DispatchBillSerializer re-serializes an already-serialized plan dict,
+        # so the method must accept both a model instance and a plain dict.
+        serializer = DispatchPlanSerializer()
+        plan = self._booked_plan_with_completed_entry()
+        plan = (
+            DispatchPlan.objects.select_related("linked_vehicle_entry")
+            .get(pk=plan.pk)
+        )
+
+        self.assertTrue(serializer.get_is_vehicle_link_locked(plan))
+        self.assertTrue(
+            serializer.get_is_vehicle_link_locked({"is_vehicle_link_locked": True})
+        )
+        self.assertFalse(
+            serializer.get_is_vehicle_link_locked({"is_vehicle_link_locked": False})
+        )
+        self.assertFalse(serializer.get_is_vehicle_link_locked({}))


### PR DESCRIPTION
DispatchBillSerializer re-serializes each pre-serialized plan dict through the nested DispatchPlanSerializer, so the new SerializerMethodField got a dict and raised AttributeError (500 on /dispatch-plans/bills/). Now reads the precomputed value when obj is a dict. Adds a regression test for both model and dict input.