### PR TITLE
chore(dispatch-plans): fix_orphaned_dispatch_links management command

### DIFF
--- a/dispatch_plans/management/commands/fix_orphaned_dispatch_links.py
+++ b/dispatch_plans/management/commands/fix_orphaned_dispatch_links.py
@@ -1,0 +1,83 @@
+"""Detect and repair dispatch plans whose linked empty-vehicle-in entry points
+to a DIFFERENT vehicle than the plan's current vehicle.
+
+This orphan state arose before vehicle linking was locked after empty-in: a
+plan's vehicle was changed after its empty-in completed, leaving a stale
+``linked_vehicle_entry`` for the old vehicle. Such a plan shows as "Locked" in
+vehicle linking yet is invisible in Empty-Vehicle-In / Docking / Empty-Vehicle-Out
+(those key off the plan's CURRENT vehicle). Clearing the stale link unlocks the
+plan and lets its real vehicle flow through a fresh empty-in.
+
+Only BOOKED/PENDING active plans are touched (dispatched/cancelled plans keep
+their history). Dry run by default; pass --apply to persist.
+"""
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils import timezone
+
+from dispatch_plans.models import DispatchPlan, DispatchPlanStatus
+
+
+class Command(BaseCommand):
+    help = (
+        "Clear stale linked_vehicle_entry on plans whose vehicle no longer "
+        "matches the linked empty-in entry (dry run unless --apply)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            help="Persist changes. Without this flag the command only reports.",
+        )
+
+    def _find_orphans(self):
+        candidates = (
+            DispatchPlan.objects.filter(
+                is_active=True,
+                linked_vehicle_entry__isnull=False,
+            )
+            .exclude(linked_vehicle_entry__vehicle_id=None)
+            .exclude(
+                booking_status__in=[
+                    DispatchPlanStatus.DISPATCHED,
+                    DispatchPlanStatus.CANCELLED,
+                ]
+            )
+            .select_related("linked_vehicle_entry")
+        )
+        return [
+            plan
+            for plan in candidates
+            if plan.vehicle_id != plan.linked_vehicle_entry.vehicle_id
+        ]
+
+    def handle(self, *args, **options):
+        apply_changes = options["apply"]
+        self.stdout.write("APPLY" if apply_changes else "DRY RUN (nothing written)")
+
+        orphans = self._find_orphans()
+        for plan in orphans:
+            entry = plan.linked_vehicle_entry
+            self.stdout.write(
+                f"plan {plan.id} co{plan.company_id} {plan.sap_invoice_doc_num} "
+                f"{plan.booking_status} | plan.vehicle {plan.vehicle_id} != "
+                f"entry.vehicle {entry.vehicle_id} | clearing linked_vehicle_entry "
+                f"{entry.id} ({entry.entry_no})"
+            )
+
+        if apply_changes and orphans:
+            with transaction.atomic():
+                for plan in orphans:
+                    # Guard on the current value so a concurrent change is not
+                    # silently overwritten.
+                    DispatchPlan.objects.filter(
+                        id=plan.id,
+                        linked_vehicle_entry_id=plan.linked_vehicle_entry_id,
+                    ).update(linked_vehicle_entry=None, updated_at=timezone.now())
+
+        verb = "Cleared" if apply_changes else "Would clear"
+        self.stdout.write(
+            self.style.SUCCESS(f"{verb} {len(orphans)} orphaned link(s).")
+        )

--- a/dispatch_plans/tests.py
+++ b/dispatch_plans/tests.py
@@ -211,6 +211,55 @@ class DispatchPlanLinkedVehicleEntryTests(TestCase):
             linked_vehicle_entry=self.vehicle_entry,
         )
 
+    def test_fix_orphaned_dispatch_links_command(self):
+        from io import StringIO
+
+        from django.core.management import call_command
+
+        other_vehicle = Vehicle.objects.create(
+            vehicle_number="HR99XX0001",
+            vehicle_type=self.vehicle.vehicle_type,
+            transporter=self.transporter,
+        )
+        other_entry = VehicleEntry.objects.create(
+            entry_no="VE-ORPHAN-1",
+            company=self.company,
+            vehicle=other_vehicle,
+            driver=self.driver,
+            entry_type="EMPTY_VEHICLE",
+            status=GateEntryStatus.COMPLETED,
+        )
+        # Orphan: plan's vehicle differs from the linked empty-in entry's vehicle.
+        orphan = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=700001,
+            booking_status="BOOKED",
+            vehicle=self.vehicle,
+            linked_vehicle_entry=other_entry,
+        )
+        # Healthy: plan's vehicle matches its linked entry's vehicle.
+        self.vehicle_entry.status = GateEntryStatus.COMPLETED
+        self.vehicle_entry.save(update_fields=["status"])
+        healthy = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=700002,
+            booking_status="BOOKED",
+            vehicle=self.vehicle,
+            linked_vehicle_entry=self.vehicle_entry,
+        )
+
+        out = StringIO()
+        call_command("fix_orphaned_dispatch_links", stdout=out)
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.linked_vehicle_entry_id, other_entry.id)  # dry run
+
+        call_command("fix_orphaned_dispatch_links", "--apply", stdout=out)
+        orphan.refresh_from_db()
+        healthy.refresh_from_db()
+        self.assertIsNone(orphan.linked_vehicle_entry_id)
+        self.assertEqual(orphan.booking_status, "BOOKED")
+        self.assertEqual(healthy.linked_vehicle_entry_id, self.vehicle_entry.id)
+
     def test_relink_blocked_once_empty_vehicle_in_completed(self):
         self._booked_plan_with_completed_entry()
         other_vehicle = Vehicle.objects.create(


### PR DESCRIPTION
Adds a management command to detect/repair dispatch plans whose linked empty-in entry points to a different vehicle than the plan current vehicle (locked in linking but invisible in empty-in/docking/empty-out). Dry run by default, --apply to persist. Includes a test. The two known orphans (plans 392, 321) were already corrected directly on the DB.