### PR TITLE
feat(dispatch-plans): link late bookings to an already-completed empty-in

### DIFF
--- a/dispatch_plans/services.py
+++ b/dispatch_plans/services.py
@@ -329,6 +329,7 @@ class DispatchPlansService:
 
         plan.updated_by = user
         plan.save()
+        self._link_completed_empty_in(plan)
         return plan
 
     @staticmethod
@@ -566,6 +567,46 @@ class DispatchPlansService:
                     "already completed for this vehicle, so the linking can no "
                     "longer be changed."
                 )
+
+    def _link_completed_empty_in(self, plan: DispatchPlan) -> None:
+        """Link a freshly-booked plan to its vehicle's already-completed empty-in.
+
+        The gate links plans to a vehicle entry when the empty-in completes, but a
+        plan booked AFTER the vehicle already came in empty would otherwise never
+        link (the gate matcher runs once, at completion). Mirror that match here so
+        a late booking still flows to docking. The departed-vehicle entries (those
+        already marked out empty) are skipped.
+        """
+        if (
+            plan.booking_status != DispatchPlanStatus.BOOKED
+            or plan.linked_vehicle_entry_id
+            or not plan.vehicle_id
+        ):
+            return
+
+        from gate_core.models import EmptyVehicleGateIn, EmptyVehicleGateOut
+
+        departed_entry_ids = EmptyVehicleGateOut.objects.filter(
+            company=self.company,
+            is_active=True,
+            status="COMPLETED",
+        ).values_list("vehicle_entry_id", flat=True)
+        vehicle_entry_id = (
+            EmptyVehicleGateIn.objects.filter(
+                company=self.company,
+                is_active=True,
+                reason="DISPATCH",
+                vehicle_id=plan.vehicle_id,
+                vehicle_entry__status="COMPLETED",
+            )
+            .exclude(vehicle_entry_id__in=departed_entry_ids)
+            .order_by("-vehicle_entry__updated_at")
+            .values_list("vehicle_entry_id", flat=True)
+            .first()
+        )
+        if vehicle_entry_id:
+            plan.linked_vehicle_entry_id = vehicle_entry_id
+            plan.save(update_fields=["linked_vehicle_entry"])
 
     def _validate_links(self, data: Dict[str, Any]) -> None:
         vehicle_id = data.get("vehicle_id")

--- a/dispatch_plans/tests.py
+++ b/dispatch_plans/tests.py
@@ -1,5 +1,6 @@
 from django.contrib.auth import get_user_model
 from django.http import QueryDict
+from django.utils import timezone
 from django.test import SimpleTestCase, TestCase
 
 from company.models import Company
@@ -210,6 +211,59 @@ class DispatchPlanLinkedVehicleEntryTests(TestCase):
             driver=self.driver,
             linked_vehicle_entry=self.vehicle_entry,
         )
+
+    def _make_dispatch_gate_in(self, status):
+        from gate_core.models import EmptyVehicleGateIn
+        self.vehicle_entry.status = status
+        self.vehicle_entry.save(update_fields=["status"])
+        return EmptyVehicleGateIn.objects.create(
+            company=self.company,
+            entry_no=self.vehicle_entry.entry_no,
+            vehicle_entry=self.vehicle_entry,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            reason="DISPATCH",
+            gate_in_date=timezone.localdate(),
+            in_time=timezone.now().time(),
+        )
+
+    def test_late_booking_links_to_completed_empty_in(self):
+        self._make_dispatch_gate_in(GateEntryStatus.COMPLETED)
+        service = DispatchPlansService(company_code=self.company.code)
+
+        plan = service.update_plan(
+            sap_invoice_doc_entry=700100,
+            data={"vehicle_id": self.vehicle.id, "booking_status": "BOOKED"},
+            user=self.user,
+        )
+
+        plan.refresh_from_db()
+        self.assertEqual(plan.linked_vehicle_entry_id, self.vehicle_entry.id)
+
+    def test_late_booking_skips_departed_empty_in(self):
+        from gate_core.models import EmptyVehicleGateOut
+        self._make_dispatch_gate_in(GateEntryStatus.COMPLETED)
+        # Vehicle already left empty -> must not relink to that entry.
+        EmptyVehicleGateOut.objects.create(
+            company=self.company,
+            entry_no="EVGO-DEP-1",
+            vehicle_entry=self.vehicle_entry,
+            vehicle=self.vehicle,
+            driver=self.driver,
+            gate_out_date=timezone.localdate(),
+            out_time=timezone.now().time(),
+            status="COMPLETED",
+        )
+        service = DispatchPlansService(company_code=self.company.code)
+
+        plan = service.update_plan(
+            sap_invoice_doc_entry=700101,
+            data={"vehicle_id": self.vehicle.id, "booking_status": "BOOKED"},
+            user=self.user,
+        )
+
+        plan.refresh_from_db()
+        self.assertIsNone(plan.linked_vehicle_entry_id)
 
     def test_fix_orphaned_dispatch_links_command(self):
         from io import StringIO


### PR DESCRIPTION
Closes the auto-matcher gap: the gate links plans at empty-in completion, so a plan booked AFTER the vehicle already came in empty never linked (showed as expected though the vehicle was inside). On booking, mirror the gate match and link to the vehicle current completed DISPATCH empty-in (skipping entries already marked empty-out). Adds positive + departed-exclusion tests; full gate_core+dispatch_plans suites pass.