### PR TITLE
feat(barcode): item-group lookup endpoint (OITM ⋈ OITB)

### DIFF
--- a/barcode/services/oitm_item_service.py
+++ b/barcode/services/oitm_item_service.py
@@ -78,6 +78,50 @@ class OitmItemService:
             logger.error('Failed to fetch OITM item rows: %s', exc)
             raise OitmItemReadError(str(exc))
 
+    def get_item(self, item_code: str) -> dict | None:
+        """Look up one item by exact code, with its item group name (OITM ⋈ OITB).
+
+        Unlike ``list_items`` this is NOT restricted to finished goods, so it can
+        report the real item group of any item. Returns ``None`` when no item
+        matches. Used to show an item's "type" (its SAP item group) on scan.
+        """
+        item_code = str(item_code or '').strip()
+        if not item_code:
+            return None
+
+        schema = self.client.context.config['hana']['schema']
+        sql = """
+            SELECT
+                T0."ItemCode",
+                T0."ItemName",
+                T0."ItmsGrpCod",
+                T1."ItmsGrpNam"
+            FROM "{schema}"."{table_name}" T0
+            LEFT JOIN "{schema}"."OITB" T1 ON T0."ItmsGrpCod" = T1."ItmsGrpCod"
+            WHERE T0."ItemCode" = ?
+        """.format(
+            schema=schema,
+            table_name=self.TABLE_NAME,
+        )
+
+        try:
+            rows = self._execute(sql, (item_code,))
+        except OitmItemReadError:
+            raise
+        except Exception as exc:
+            logger.error('Failed to fetch OITM item %s: %s', item_code, exc)
+            raise OitmItemReadError(str(exc))
+
+        if not rows:
+            return None
+        row = rows[0]
+        return {
+            'item_code': row.get('ItemCode') or '',
+            'item_name': row.get('ItemName') or '',
+            'item_group_code': self._to_int(row.get('ItmsGrpCod')),
+            'item_group_name': (row.get('ItmsGrpNam') or '').strip(),
+        }
+
     def find_item_codes_by_oil_item_code(self, oil_item_code: str) -> list[str]:
         oil_item_code = str(oil_item_code or '').strip()
         if not oil_item_code:

--- a/barcode/urls.py
+++ b/barcode/urls.py
@@ -28,7 +28,7 @@ from .views import (
     IntercompanyTransferDetailAPI, IntercompanyTransferListCreateAPI,
     IntercompanyTransferReverseAPI, IntercompanyTransferScanAPI,
     ProductionRunLabelsAPI, ProductionRunPalletAPI, ProductionReleaseOilListAPI,
-    OitmItemListAPI,
+    OitmItemListAPI, OitmItemDetailAPI,
 )
 
 urlpatterns = [
@@ -137,6 +137,7 @@ urlpatterns = [
     # Production Integration
     # ------------------------------------------------------------------
     path('items/oitm/', OitmItemListAPI.as_view(), name='bc-oitm-items'),
+    path('items/oitm/detail/', OitmItemDetailAPI.as_view(), name='bc-oitm-item-detail'),
     path('production-release-oil/', ProductionReleaseOilListAPI.as_view(), name='bc-production-release-oil'),
     path('production/<int:run_id>/generate-labels/', ProductionRunLabelsAPI.as_view(), name='bc-production-labels'),
     path('production/<int:run_id>/create-pallet/', ProductionRunPalletAPI.as_view(), name='bc-production-pallet'),

--- a/barcode/views.py
+++ b/barcode/views.py
@@ -1473,6 +1473,30 @@ class OitmItemListAPI(APIView):
         return Response(rows)
 
 
+class OitmItemDetailAPI(APIView):
+    """Look up one item's group (code + name) from SAP HANA OITM/OITB by code."""
+    permission_classes = [IsAuthenticated, HasCompanyContext, HasAnyBarcodePermission]
+
+    def get(self, request):
+        item_code = request.query_params.get('item_code', '').strip()
+        if not item_code:
+            return Response(
+                {'error': 'item_code is required.'},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            service = OitmItemService(company_code=request.company.company.code)
+            item = service.get_item(item_code)
+        except OitmItemReadError as e:
+            return Response(
+                {'error': str(e)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        if item is None:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+        return Response(item)
+
+
 class ProductionRunPalletAPI(APIView):
     """Create a pallet linked to a production run."""
     permission_classes = [IsAuthenticated, HasCompanyContext, HasAnyBarcodePermission]


### PR DESCRIPTION
Adds `OitmItemService.get_item()` + `GET /barcode/items/oitm/detail/?item_code=…` returning an item's SAP item group code and name (OITM joined to OITB). Unlike `list_items` it is not restricted to finished goods and is keyed by exact item code.

Powers the read-only "Item type" field on the Warehouse Ops pallet-first Receive page (paired FactoryFlow PR). Same permission as the barcode scan lookup (`HasAnyBarcodePermission`).

`manage.py check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)