### PR TITLE
feat(wms): location-filtered movements + clear dispatched pallets off the map

### DIFF
--- a/barcode/services/dispatch_service.py
+++ b/barcode/services/dispatch_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import uuid
 import re
 from collections import defaultdict
@@ -44,6 +45,9 @@ from ..models import (
     PalletStatus,
 )
 from .scan_service import ScanService
+from .wms_sync import reconcile_pallet_to_wms
+
+logger = logging.getLogger(__name__)
 
 
 class DispatchValidationError(ValueError):
@@ -2047,6 +2051,13 @@ class BarcodeDispatchService:
             "total_qty",
             "updated_at",
         ])
+        # Keep the Warehouse Ops map in sync: a dispatched/emptied pallet is
+        # removed from its bin (and a partial dispatch decrements it) so the map
+        # never shows phantom stock. Best-effort — never block a dispatch on it.
+        try:
+            reconcile_pallet_to_wms(self.company, pallet)
+        except Exception:  # noqa: BLE001 - WMS sync must not break dispatch
+            logger.exception("WMS reconcile failed for pallet %s", pallet.pallet_id)
 
     def _get_active_line(self, session: DispatchSession) -> DispatchSessionLine | None:
         return (

--- a/barcode/services/wms_sync.py
+++ b/barcode/services/wms_sync.py
@@ -1,0 +1,98 @@
+"""Keep the Warehouse Ops (``wms``) map in sync with barcode pallet lifecycle
+events that happen *outside* the WMS module.
+
+The WMS module renders its own ``Pallet``/``Inventory`` records. When a barcode
+pallet is dispatched (or otherwise emptied) through the dispatch/docking flow,
+nothing in that flow touches WMS — so the pallet would linger on the map as
+phantom stock. ``reconcile_pallet_to_wms`` closes that gap: it removes the WMS
+pallet + its inventory when the pallet has left (dispatched / no boxes left), or
+decrements the box count / quantity when only some boxes were dispatched.
+
+Matched by license plate, so it covers both WMS pallet representations — the
+receive/putaway records (keyed by their own uuid) and the pallet-move mirror
+inventory (``bc-pallet-<id>``).
+"""
+import uuid
+
+from django.utils import timezone
+
+from ..models import PalletStatus
+
+
+def reconcile_pallet_to_wms(company, pallet, *, note="Dispatched"):
+    """Sync one barcode pallet's remaining state into the WMS map."""
+    from wms.models import (
+        Inventory as WmsInventory,
+        Movement as WmsMovement,
+        Pallet as WmsPallet,
+    )
+
+    plate = (pallet.pallet_id or "").strip()
+    if not plate:
+        return
+
+    # "Gone" = the pallet no longer holds stock at its bin (fully dispatched or
+    # emptied). box_count is the remaining active-box count after recalculation.
+    gone = (pallet.box_count or 0) <= 0 or pallet.status == PalletStatus.DISPATCHED
+    now = timezone.now().isoformat()
+
+    for wms_pallet in WmsPallet.objects.filter(company=company, data__licensePlate=plate):
+        data = wms_pallet.data or {}
+        location_id = data.get("currentLocationId")
+        inventory_qs = WmsInventory.objects.filter(
+            company=company, data__palletId=wms_pallet.record_id
+        )
+        if gone:
+            # Leave an OUTBOUND entry so the cell's audit trail records the exit.
+            if location_id:
+                record_id = str(uuid.uuid4())
+                WmsMovement.objects.create(
+                    company=company,
+                    record_id=record_id,
+                    data={
+                        "id": record_id,
+                        "type": "OUTBOUND",
+                        "itemCode": data.get("itemCode", ""),
+                        "itemName": data.get("itemName", ""),
+                        "palletId": wms_pallet.record_id,
+                        "fromLocationId": location_id,
+                        "toLocationId": None,
+                        "quantity": float(data.get("totalUnits") or 0),
+                        "boxCount": data.get("boxCount") or 0,
+                        "lotNumber": data.get("lotNumber", ""),
+                        "userId": "",
+                        "userName": "Dispatch",
+                        "note": note,
+                        "createdAt": now,
+                    },
+                )
+            inventory_qs.delete()
+            wms_pallet.delete()
+        else:
+            # Partial dispatch — the pallet is still at its bin with fewer boxes.
+            data.update(
+                {
+                    "boxCount": pallet.box_count or 0,
+                    "totalUnits": float(pallet.total_qty or 0),
+                    "updatedAt": now,
+                }
+            )
+            wms_pallet.data = data
+            wms_pallet.save(update_fields=["data", "updated_at"])
+            for inventory in inventory_qs:
+                inv_data = inventory.data or {}
+                inv_data.update(
+                    {
+                        "boxCount": pallet.box_count or 0,
+                        "quantity": float(pallet.total_qty or 0),
+                        "updatedAt": now,
+                    }
+                )
+                inventory.data = inv_data
+                inventory.save(update_fields=["data", "updated_at"])
+
+    # Drop the pallet-move bridge mirror inventory too once the pallet is gone.
+    if gone:
+        WmsInventory.objects.filter(
+            company=company, record_id=f"bc-pallet-{pallet.id}"
+        ).delete()

--- a/wms/views.py
+++ b/wms/views.py
@@ -24,6 +24,7 @@ import logging
 import uuid
 
 from django.db import transaction
+from django.db.models import Q
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -122,6 +123,20 @@ class WmsCollectionAPI(_WmsBaseView):
         warehouse_id = request.query_params.get('warehouseId')
         if warehouse_id:
             qs = qs.filter(data__warehouseId=warehouse_id)
+
+        # Optional filter by a location this record touches — a movement's audit
+        # trail for one cell is every entry whose from/to location is that cell.
+        # (Locations/zones carry ``warehouseId``; movements carry from/toLocationId.)
+        location_id = request.query_params.get('locationId')
+        if location_id:
+            qs = qs.filter(
+                Q(data__fromLocationId=location_id) | Q(data__toLocationId=location_id)
+            )
+
+        # Optional newest-first ordering (the default is created_at ascending, kept
+        # for backward compatibility). An audit trail reads newest-first.
+        if request.query_params.get('order') == '-created_at':
+            qs = qs.order_by('-created_at')
 
         # Optional, backward-compatible pagination: with no ?limit the full list
         # is returned as a plain array (what the storage adapter expects); with


### PR DESCRIPTION
Two Warehouse Ops map improvements:

**1. Per-cell audit trail (query support).** The WMS list endpoint now accepts `?locationId=` (matches a record's `from`/`toLocationId` via OR) and `?order=-created_at`, so a cell's movement history can be fetched server-paginated, newest-first. Backward compatible — no params → unchanged behaviour. (Paired with the FactoryFlow audit-trail UI.)

**2. Dispatch → WMS sync (phantom-stock fix).** Dispatching boxes/pallets through the docking flow previously never touched Warehouse Ops, so shipped pallets lingered on the map. New `barcode/services/wms_sync.reconcile_pallet_to_wms`, called from `_recalculate_pallet_state`, removes a fully-dispatched/emptied pallet from its bin (with an OUTBOUND audit entry) and decrements a partially-dispatched one. Best-effort — wrapped so a WMS hiccup can never block a dispatch.

Validated against live data in a rolled-back transaction (full dispatch → pallet removed + OUTBOUND written; partial → decremented). `manage.py check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)