### PR TITLE
feat: Implement cost calculation for production runs

### DIFF
--- a/production_execution/management/commands/recalc_run_costs.py
+++ b/production_execution/management/commands/recalc_run_costs.py
@@ -1,0 +1,52 @@
+"""Backfill derived run costs (Cost Master x execution time) for existing runs.
+
+The costing engine only recomputes a run's cost when it's triggered (run
+complete / resource save). After changing rates in the Cost Master, or after
+first enabling the engine, run this to recompute historical runs so the
+dashboard cost section reflects the current rates.
+
+    python manage.py recalc_run_costs --company JIVO_OIL --date-from 2026-07-01
+"""
+from django.core.management.base import BaseCommand
+
+from production_execution.models import ProductionRun
+from production_execution.services.cost_calculator import recalculate_run_cost
+
+
+class Command(BaseCommand):
+    help = "Recompute ProductionRunCost from the Cost Master for existing runs."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--company", help="Company code (e.g. JIVO_OIL). Default: all.")
+        parser.add_argument("--date-from", help="ISO date (inclusive).")
+        parser.add_argument("--date-to", help="ISO date (inclusive).")
+        parser.add_argument("--line", type=int, help="Production line id.")
+        parser.add_argument(
+            "--completed-only", action="store_true",
+            help="Only runs with status COMPLETED (default: all runs).",
+        )
+
+    def handle(self, *args, **opts):
+        qs = ProductionRun.objects.all()
+        if opts.get("company"):
+            qs = qs.filter(company__code=opts["company"])
+        if opts.get("date_from"):
+            qs = qs.filter(date__gte=opts["date_from"])
+        if opts.get("date_to"):
+            qs = qs.filter(date__lte=opts["date_to"])
+        if opts.get("line"):
+            qs = qs.filter(line_id=opts["line"])
+        if opts.get("completed_only"):
+            qs = qs.filter(status="COMPLETED")
+
+        total = qs.count()
+        self.stdout.write(f"Recalculating cost for {total} run(s)...")
+        ok = err = 0
+        for run in qs.iterator():
+            try:
+                recalculate_run_cost(run)
+                ok += 1
+            except Exception as exc:  # noqa: BLE001 - report and continue
+                err += 1
+                self.stderr.write(f"  run {run.id}: {exc}")
+        self.stdout.write(self.style.SUCCESS(f"Done. {ok} recalculated, {err} failed."))

--- a/production_execution/models.py
+++ b/production_execution/models.py
@@ -84,6 +84,32 @@ class ProductionLine(models.Model):
     )
     name = models.CharField(max_length=100)
     description = models.TextField(blank=True, default='')
+
+    # --- Cost / operating profile (drives automatic run costing) ------------
+    standard_hours_per_month = models.DecimalField(
+        max_digits=8, decimal_places=2, default=572,
+        help_text=(
+            "Standard operating hours per month for this line (e.g. 26 days "
+            "x 22 hr = 572). Denominator for apportioning PER_MONTH fixed costs "
+            "onto a run: (rate/month / std_hours) x run_running_hours."
+        )
+    )
+    standard_hours_per_day = models.DecimalField(
+        max_digits=6, decimal_places=2, default=22,
+        help_text=(
+            "Standard operating hours per day for this line. Denominator for "
+            "apportioning PER_DAY fixed costs: (rate/day / std_hours_per_day) "
+            "x run_running_hours."
+        )
+    )
+    electricity_units_per_hour = models.DecimalField(
+        max_digits=12, decimal_places=4, null=True, blank=True,
+        help_text=(
+            "Standard electricity units (kWh) drawn per running hour. "
+            "Variable electricity cost = this x running_hours x rate/unit."
+        )
+    )
+
     is_active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
@@ -228,6 +254,91 @@ class LineSkuConfig(models.Model):
 
     def __str__(self):
         return f"{self.line.name} — {self.config_name}"
+
+
+class CostCategory(models.TextChoices):
+    MATERIAL = "MATERIAL", "BOM Material"
+    ELECTRICITY_VARIABLE = "ELECTRICITY_VARIABLE", "Electricity — Variable"
+    ELECTRICITY_FIXED = "ELECTRICITY_FIXED", "Electricity — Fixed (Demand Charge)"
+    LABOUR = "LABOUR", "Labour"
+    MANPOWER_SALARIED = "MANPOWER_SALARIED", "Supervisor / Salaried Manpower"
+    LUBRICATION = "LUBRICATION", "Lubrication"
+    LAB_CHEMICALS = "LAB_CHEMICALS", "Lab Chemicals"
+    BATCH_CODING = "BATCH_CODING", "Batch Coding (Ink)"
+    MAINTENANCE = "MAINTENANCE", "Maintenance / Spares"
+    WATER = "WATER", "Water"
+    OVERHEAD = "OVERHEAD", "Overhead (Rent / Admin / ETP)"
+    WASTE_RECOVERY = "WASTE_RECOVERY", "Waste Sale Recovery"
+    OTHER = "OTHER", "Other"
+
+
+class CostBasis(models.TextChoices):
+    PER_UNIT = "PER_UNIT", "Per Unit (per case produced)"
+    PER_HOUR = "PER_HOUR", "Per Hour (per running hour)"
+    PER_DAY = "PER_DAY", "Per Day (fixed — apportioned)"
+    PER_MONTH = "PER_MONTH", "Per Month (fixed — apportioned)"
+
+
+class CostRate(models.Model):
+    """
+    Cost master catalog. One row = one rate for a cost category, on a given
+    basis. Layered: a row with ``line = NULL`` is the company-wide default;
+    a row with ``line`` set overrides the default for that line.
+
+    The automatic run-costing engine resolves, per run, the most specific
+    active rate per category (line override > global) and applies it:
+        PER_UNIT  -> rate x produced_cases
+        PER_HOUR  -> rate x running_hours
+        PER_MONTH -> (rate / line.standard_hours_per_month) x running_hours
+    ``is_credit`` rows (e.g. waste sale recovery) reduce the net cost.
+    """
+    company = models.ForeignKey(
+        'company.Company', on_delete=models.PROTECT,
+        related_name='cost_rates'
+    )
+    line = models.ForeignKey(
+        ProductionLine, on_delete=models.CASCADE,
+        related_name='cost_rates', null=True, blank=True,
+        help_text="NULL = company-wide default; set = per-line override."
+    )
+    category = models.CharField(max_length=30, choices=CostCategory.choices)
+    basis = models.CharField(max_length=20, choices=CostBasis.choices)
+    rate = models.DecimalField(
+        max_digits=15, decimal_places=4, default=0,
+        help_text="Rate value, interpreted per the basis."
+    )
+    is_credit = models.BooleanField(
+        default=False,
+        help_text="True if this reduces net cost (e.g. waste sale recovery)."
+    )
+    label = models.CharField(
+        max_length=200, blank=True, default='',
+        help_text="Optional custom label (e.g. 'Diesel for DG set')."
+    )
+    is_active = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        ordering = ['line', 'category']
+        verbose_name = 'Cost Rate'
+        verbose_name_plural = 'Cost Rates'
+        constraints = [
+            models.UniqueConstraint(
+                fields=['company', 'category'],
+                condition=models.Q(line__isnull=True, is_active=True),
+                name='uniq_active_global_cost_rate_per_category',
+            ),
+            models.UniqueConstraint(
+                fields=['company', 'line', 'category'],
+                condition=models.Q(line__isnull=False, is_active=True),
+                name='uniq_active_line_cost_rate_per_category',
+            ),
+        ]
+
+    def __str__(self):
+        scope = self.line.name if self.line_id else "GLOBAL"
+        return f"{scope} — {self.get_category_display()} @ {self.rate} ({self.basis})"
 
 
 # ---------------------------------------------------------------------------
@@ -475,6 +586,10 @@ class ProductionMaterialUsage(models.Model):
     wastage_qty = models.DecimalField(
         max_digits=12, decimal_places=3, default=0,
         help_text="Calculated: opening + issued - closing"
+    )
+    unit_price = models.DecimalField(
+        max_digits=15, decimal_places=4, null=True, blank=True,
+        help_text="SAP unit price (LastPurPrc) snapshotted at run start. Drives material cost."
     )
     uom = models.CharField(max_length=20, blank=True, default='')
     created_at = models.DateTimeField(auto_now_add=True)
@@ -935,7 +1050,18 @@ class ProductionRunCost(models.Model):
     gas_cost = models.DecimalField(max_digits=15, decimal_places=2, default=0)
     compressed_air_cost = models.DecimalField(max_digits=15, decimal_places=2, default=0)
     overhead_cost = models.DecimalField(max_digits=15, decimal_places=2, default=0)
-    total_cost = models.DecimalField(max_digits=15, decimal_places=2, default=0)
+    waste_recovery_credit = models.DecimalField(
+        max_digits=15, decimal_places=2, default=0,
+        help_text="Value recovered by selling waste/scrap (a credit)."
+    )
+    total_cost = models.DecimalField(
+        max_digits=15, decimal_places=2, default=0,
+        help_text="Sum of all cost components (before credits)."
+    )
+    net_cost = models.DecimalField(
+        max_digits=15, decimal_places=2, default=0,
+        help_text="total_cost minus credits (e.g. waste recovery)."
+    )
     produced_qty = models.DecimalField(max_digits=15, decimal_places=3, default=0)
     per_unit_cost = models.DecimalField(max_digits=15, decimal_places=4, default=0)
     calculated_at = models.DateTimeField(auto_now=True)
@@ -946,6 +1072,35 @@ class ProductionRunCost(models.Model):
 
     def __str__(self):
         return f"Cost for Run #{self.production_run.run_number} — Per Unit: {self.per_unit_cost}"
+
+
+class ProductionRunCostLine(models.Model):
+    """One derived cost line per category for a run. Written by the automatic
+    costing engine (``cost_calculator.recalculate_run_cost``). The authoritative
+    per-category breakdown behind the ``ProductionRunCost`` rollup header."""
+    production_run = models.ForeignKey(
+        ProductionRun, on_delete=models.CASCADE, related_name='cost_lines'
+    )
+    category = models.CharField(max_length=30, choices=CostCategory.choices)
+    basis = models.CharField(max_length=20, choices=CostBasis.choices, blank=True, default='')
+    quantity = models.DecimalField(max_digits=18, decimal_places=4, default=0)
+    rate = models.DecimalField(max_digits=15, decimal_places=4, default=0)
+    amount = models.DecimalField(max_digits=15, decimal_places=2, default=0)
+    is_credit = models.BooleanField(default=False)
+    note = models.CharField(
+        max_length=200, blank=True, default='',
+        help_text="Human-readable calc note, e.g. '120 kWh × ₹7.00'."
+    )
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ['production_run', 'category']
+        unique_together = ('production_run', 'category')
+        verbose_name = 'Production Run Cost Line'
+        verbose_name_plural = 'Production Run Cost Lines'
+
+    def __str__(self):
+        return f"{self.get_category_display()} — {self.amount}"
 
 
 # ---------------------------------------------------------------------------

--- a/production_execution/serializers.py
+++ b/production_execution/serializers.py
@@ -7,14 +7,14 @@ from maintenance.constants import MaintenancePriority
 
 from .models import (
     ProductionLine, Machine, MachineChecklistTemplate,
-    BreakdownCategory, LineSkuConfig,
+    BreakdownCategory, LineSkuConfig, CostRate,
     ProductionRun, ProductionSegment, MachineBreakdown,
     ProductionMaterialUsage, MachineRuntime, ProductionManpower,
     LineClearance, LineClearanceItem,
     MachineChecklistEntry, WasteLog,
     ResourceElectricity, ResourceWater, ResourceGas, ResourceCompressedAir,
     ResourceLabour, ResourceMachineCost, ResourceOverhead,
-    ProductionRunCost, InProcessQCCheck, FinalQCCheck,
+    ProductionRunCost, ProductionRunCostLine, InProcessQCCheck, FinalQCCheck,
 )
 
 
@@ -25,13 +25,27 @@ from .models import (
 class ProductionLineSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductionLine
-        fields = ['id', 'name', 'description', 'is_active', 'created_at', 'updated_at']
+        fields = [
+            'id', 'name', 'description',
+            'standard_hours_per_month', 'standard_hours_per_day',
+            'electricity_units_per_hour',
+            'is_active', 'created_at', 'updated_at',
+        ]
         read_only_fields = ['created_at', 'updated_at']
 
 
 class ProductionLineCreateSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=100)
     description = serializers.CharField(required=False, allow_blank=True, default='')
+    standard_hours_per_month = serializers.DecimalField(
+        max_digits=8, decimal_places=2, required=False, allow_null=True
+    )
+    standard_hours_per_day = serializers.DecimalField(
+        max_digits=6, decimal_places=2, required=False, allow_null=True
+    )
+    electricity_units_per_hour = serializers.DecimalField(
+        max_digits=12, decimal_places=4, required=False, allow_null=True
+    )
 
 
 class MachineSerializer(serializers.ModelSerializer):
@@ -364,6 +378,7 @@ class MaterialUsageSerializer(serializers.ModelSerializer):
         fields = [
             'id', 'material_code', 'material_name',
             'opening_qty', 'issued_qty', 'closing_qty', 'wastage_qty',
+            'unit_price',
             'bom_quantity', 'wastage_percentage', 'wastage_quantity',
             'final_consumption_quantity',
             'uom', 'created_at', 'updated_at',
@@ -789,19 +804,32 @@ class ResourceOverheadCreateSerializer(serializers.Serializer):
 # Cost Summary Serializer
 # ---------------------------------------------------------------------------
 
+class ProductionRunCostLineSerializer(serializers.ModelSerializer):
+    category_display = serializers.CharField(source='get_category_display', read_only=True)
+
+    class Meta:
+        model = ProductionRunCostLine
+        fields = [
+            'id', 'category', 'category_display', 'basis',
+            'quantity', 'rate', 'amount', 'is_credit', 'note',
+        ]
+        read_only_fields = fields
+
+
 class ProductionRunCostSerializer(serializers.ModelSerializer):
+    lines = ProductionRunCostLineSerializer(
+        source='production_run.cost_lines', many=True, read_only=True
+    )
+
     class Meta:
         model = ProductionRunCost
         fields = [
             'id', 'raw_material_cost', 'labour_cost', 'machine_cost',
             'electricity_cost', 'water_cost', 'gas_cost', 'compressed_air_cost',
-            'overhead_cost', 'total_cost', 'produced_qty', 'per_unit_cost', 'calculated_at'
+            'overhead_cost', 'waste_recovery_credit', 'total_cost', 'net_cost',
+            'produced_qty', 'per_unit_cost', 'calculated_at', 'lines',
         ]
-        read_only_fields = [
-            'id', 'raw_material_cost', 'labour_cost', 'machine_cost',
-            'electricity_cost', 'water_cost', 'gas_cost', 'compressed_air_cost',
-            'overhead_cost', 'total_cost', 'produced_qty', 'per_unit_cost', 'calculated_at'
-        ]
+        read_only_fields = fields
 
 
 # ---------------------------------------------------------------------------
@@ -1047,3 +1075,41 @@ class LineSkuConfigUpdateSerializer(serializers.Serializer):
     labour_cost_per_hour = serializers.DecimalField(max_digits=12, decimal_places=4, required=False, allow_null=True)
     supervisor = serializers.CharField(max_length=200, required=False, allow_blank=True)
     operators = serializers.CharField(max_length=500, required=False, allow_blank=True)
+
+
+# ---------------------------------------------------------------------------
+# Cost Master (CostRate) Serializers
+# ---------------------------------------------------------------------------
+
+class CostRateSerializer(serializers.ModelSerializer):
+    line_name = serializers.CharField(source='line.name', read_only=True, default=None)
+    category_display = serializers.CharField(source='get_category_display', read_only=True)
+    basis_display = serializers.CharField(source='get_basis_display', read_only=True)
+
+    class Meta:
+        model = CostRate
+        fields = [
+            'id', 'line', 'line_name', 'category', 'category_display',
+            'basis', 'basis_display', 'rate', 'is_credit', 'label',
+            'is_active', 'created_at', 'updated_at',
+        ]
+        read_only_fields = ['id', 'line_name', 'category_display', 'basis_display',
+                            'created_at', 'updated_at']
+
+
+class CostRateCreateSerializer(serializers.Serializer):
+    line_id = serializers.IntegerField(required=False, allow_null=True)
+    category = serializers.ChoiceField(choices=CostRate._meta.get_field('category').choices)
+    basis = serializers.ChoiceField(choices=CostRate._meta.get_field('basis').choices)
+    rate = serializers.DecimalField(max_digits=15, decimal_places=4)
+    is_credit = serializers.BooleanField(required=False, default=False)
+    label = serializers.CharField(max_length=200, required=False, allow_blank=True, default='')
+
+
+class CostRateUpdateSerializer(serializers.Serializer):
+    basis = serializers.ChoiceField(
+        choices=CostRate._meta.get_field('basis').choices, required=False
+    )
+    rate = serializers.DecimalField(max_digits=15, decimal_places=4, required=False)
+    is_credit = serializers.BooleanField(required=False)
+    label = serializers.CharField(max_length=200, required=False, allow_blank=True)

--- a/production_execution/services/cost_calculator.py
+++ b/production_execution/services/cost_calculator.py
@@ -1,84 +1,198 @@
+"""Automatic run-costing engine.
+
+Run cost is *derived* — there is no manual per-run cost entry. Everything is
+computed from:
+  - the **Cost master** rates (``CostRate``: per-line override > company global)
+  - the **Line master** operating profile (``standard_hours_per_month``,
+    ``electricity_units_per_hour``)
+  - the **BOM material snapshot** on the run (``ProductionMaterialUsage.unit_price``)
+  - the run's actuals: running hours ``H`` and produced cases ``Q``.
+
+Per category:
+  MATERIAL              Σ(consumed_qty × snapshot unit_price)         [from BOM]
+  ELECTRICITY_VARIABLE  (units/hr × H) × rate
+  LABOUR                (labour_count × H) × rate                     [PER_HOUR]
+  WASTE_RECOVERY        waste_qty × rate                             [credit]
+  everything else, by basis:
+      PER_UNIT          Q × rate
+      PER_HOUR          H × rate
+      PER_MONTH         (rate / std_hours_per_month) × H
+
+Results are written to ``ProductionRunCostLine`` (per-category breakdown) and
+summarised into the ``ProductionRunCost`` rollup header.
+"""
 import logging
 from decimal import Decimal
 
+from django.db.models import Q, Sum
+
 logger = logging.getLogger(__name__)
+
+ZERO = Decimal('0')
+
+
+def _resolve_rates(company, line):
+    """Return {category: CostRate}, with a per-line override beating the global."""
+    from production_execution.models import CostRate
+
+    resolved = {}
+    qs = CostRate.objects.filter(company=company, is_active=True).filter(
+        Q(line__isnull=True) | Q(line=line)
+    )
+    for rate in qs:
+        current = resolved.get(rate.category)
+        # Line-specific always wins; otherwise first-seen (global) fills the slot.
+        if current is None or rate.line_id is not None:
+            resolved[rate.category] = rate
+    return resolved
+
+
+def _q2(value: Decimal) -> Decimal:
+    return (value or ZERO).quantize(Decimal('0.01'))
 
 
 def recalculate_run_cost(production_run) -> None:
-    """
-    Recalculate and persist the ProductionRunCost for a given run.
-    Called after any resource or material save/delete.
-    """
-    from production_execution.models import ProductionRunCost
-
-    # Material costs — use wastage_qty approach: (opening + issued - closing) * unit_cost
-    # For existing material entries without unit_cost, skip
-    raw_material_cost = Decimal('0')
-    for m in production_run.material_usages.all():
-        unit_cost = getattr(m, 'unit_cost', None)
-        if unit_cost:
-            qty_used = m.opening_qty + m.issued_qty - m.closing_qty
-            raw_material_cost += qty_used * Decimal(str(unit_cost))
-        else:
-            raw_material_cost += getattr(m, 'total_cost', Decimal('0'))
-
-    labour_cost = sum(
-        r.total_cost for r in production_run.labour_entries.all()
-    )
-    machine_cost = sum(
-        r.total_cost for r in production_run.machine_cost_entries.all()
-    )
-    electricity_cost = sum(
-        r.total_cost for r in production_run.electricity_usage.all()
-    )
-    water_cost = sum(
-        r.total_cost for r in production_run.water_usage.all()
-    )
-    gas_cost = sum(
-        r.total_cost for r in production_run.gas_usage.all()
-    )
-    compressed_air_cost = sum(
-        r.total_cost for r in production_run.compressed_air_usage.all()
-    )
-    overhead_cost = sum(
-        r.amount for r in production_run.overhead_entries.all()
+    """Recalculate and persist the derived cost (lines + rollup) for a run."""
+    from production_execution.models import (
+        CostCategory as C,
+        CostBasis as B,
+        ProductionRunCost,
+        ProductionRunCostLine,
     )
 
-    # Ensure all are Decimal
-    def to_dec(v):
-        return Decimal(str(v)) if v else Decimal('0')
+    run = production_run
+    line = run.line
+    company = run.company
 
-    labour_cost = to_dec(labour_cost)
-    machine_cost = to_dec(machine_cost)
-    electricity_cost = to_dec(electricity_cost)
-    water_cost = to_dec(water_cost)
-    gas_cost = to_dec(gas_cost)
-    compressed_air_cost = to_dec(compressed_air_cost)
-    overhead_cost = to_dec(overhead_cost)
+    H = Decimal(run.total_running_minutes or 0) / Decimal('60')  # running hours
+    Q = Decimal(str(run.total_production or 0))                   # produced cases
+    labour_count = Decimal(run.labour_count or 0)
+    elec_units_per_hour = Decimal(str(line.electricity_units_per_hour or 0))
+    std_hours = Decimal(str(line.standard_hours_per_month or 0))
+    std_hours_per_day = Decimal(str(line.standard_hours_per_day or 0))
 
-    total_cost = (
-        raw_material_cost + labour_cost + machine_cost +
-        electricity_cost + water_cost + gas_cost +
-        compressed_air_cost + overhead_cost
+    waste_qty = Decimal(str(
+        run.waste_logs.aggregate(t=Sum('wastage_qty'))['t'] or 0
+    ))
+
+    rates = _resolve_rates(company, line)
+    computed = []  # list of dicts → ProductionRunCostLine
+
+    # --- Material (from BOM snapshot; not a CostRate) -----------------------
+    material_amount = ZERO
+    material_items = 0
+    for m in run.material_usages.all():
+        if m.unit_price is None:
+            continue
+        consumed = (m.opening_qty or ZERO) + (m.issued_qty or ZERO) - (m.closing_qty or ZERO)
+        material_amount += Decimal(str(consumed)) * m.unit_price
+        material_items += 1
+    if material_amount != ZERO:
+        computed.append({
+            'category': C.MATERIAL, 'basis': '', 'quantity': Q, 'rate': ZERO,
+            'amount': _q2(material_amount), 'is_credit': False,
+            'note': f"{material_items} BOM item(s) × LastPurPrc",
+        })
+
+    # --- Rate-driven categories --------------------------------------------
+    for category, rate_row in rates.items():
+        rate = rate_row.rate or ZERO
+        basis = rate_row.basis
+        qty = ZERO
+        amount = ZERO
+        note = ''
+
+        if category == C.ELECTRICITY_VARIABLE:
+            qty = elec_units_per_hour * H
+            amount = qty * rate
+            note = f"{qty:.2f} units × ₹{rate}"
+        elif category == C.LABOUR:
+            qty = labour_count * H
+            amount = qty * rate
+            note = f"{labour_count:.0f} × {H:.2f} h × ₹{rate}"
+        elif category == C.WASTE_RECOVERY:
+            qty = waste_qty
+            amount = qty * rate
+            note = f"{qty} × ₹{rate} (credit)"
+        elif basis == B.PER_UNIT:
+            qty = Q
+            amount = Q * rate
+            note = f"{Q} cases × ₹{rate}"
+        elif basis == B.PER_HOUR:
+            qty = H
+            amount = H * rate
+            note = f"{H:.2f} h × ₹{rate}"
+        elif basis == B.PER_DAY:
+            if std_hours_per_day > 0:
+                qty = H
+                amount = (rate / std_hours_per_day) * H
+                note = f"₹{rate}/day ÷ {std_hours_per_day:.0f} h × {H:.2f} h"
+            else:
+                note = "no std hours/day set on line"
+        elif basis == B.PER_MONTH:
+            if std_hours > 0:
+                qty = H
+                amount = (rate / std_hours) * H
+                note = f"₹{rate}/mo ÷ {std_hours:.0f} h × {H:.2f} h"
+            else:
+                note = "no std hours/month set on line"
+
+        if amount == ZERO:
+            continue
+        computed.append({
+            'category': category, 'basis': basis, 'quantity': qty, 'rate': rate,
+            'amount': _q2(amount), 'is_credit': rate_row.is_credit,
+            'note': note,
+        })
+
+    # --- Persist cost lines -------------------------------------------------
+    run.cost_lines.all().delete()
+    ProductionRunCostLine.objects.bulk_create([
+        ProductionRunCostLine(production_run=run, **c) for c in computed
+    ])
+
+    # --- Roll up into the summary header -----------------------------------
+    by_cat = {c['category']: c['amount'] for c in computed}
+
+    def amt(*cats):
+        return sum((by_cat.get(c, ZERO) for c in cats), ZERO)
+
+    raw_material_cost = amt(C.MATERIAL)
+    labour_cost = amt(C.LABOUR, C.MANPOWER_SALARIED)
+    electricity_cost = amt(C.ELECTRICITY_VARIABLE, C.ELECTRICITY_FIXED)
+    water_cost = amt(C.WATER)
+    overhead_cost = amt(
+        C.LUBRICATION, C.LAB_CHEMICALS, C.BATCH_CODING,
+        C.MAINTENANCE, C.OVERHEAD, C.OTHER,
     )
+    waste_recovery_credit = amt(C.WASTE_RECOVERY)
 
-    produced = Decimal(str(production_run.total_production or 0))
-    per_unit = (total_cost / produced) if produced > 0 else Decimal('0')
+    total_cost = sum(
+        (c['amount'] for c in computed if not c['is_credit']), ZERO
+    )
+    credits = sum((c['amount'] for c in computed if c['is_credit']), ZERO)
+    net_cost = total_cost - credits
+    per_unit = (net_cost / Q) if Q > 0 else ZERO
 
     ProductionRunCost.objects.update_or_create(
-        production_run=production_run,
+        production_run=run,
         defaults={
             'raw_material_cost': raw_material_cost,
             'labour_cost': labour_cost,
-            'machine_cost': machine_cost,
+            'machine_cost': ZERO,
             'electricity_cost': electricity_cost,
             'water_cost': water_cost,
-            'gas_cost': gas_cost,
-            'compressed_air_cost': compressed_air_cost,
+            'gas_cost': ZERO,
+            'compressed_air_cost': ZERO,
             'overhead_cost': overhead_cost,
-            'total_cost': total_cost,
-            'produced_qty': produced,
-            'per_unit_cost': per_unit,
+            'waste_recovery_credit': waste_recovery_credit,
+            'total_cost': _q2(total_cost),
+            'net_cost': _q2(net_cost),
+            'produced_qty': Q,
+            'per_unit_cost': per_unit.quantize(Decimal('0.0001')),
         }
     )
-    logger.debug(f"Recalculated cost for run {production_run.id}: total={total_cost}, per_unit={per_unit}")
+    logger.debug(
+        f"Recalculated cost for run {run.id}: total={total_cost}, "
+        f"net={net_cost}, per_unit={per_unit}"
+    )

--- a/production_execution/services/production_service.py
+++ b/production_execution/services/production_service.py
@@ -741,6 +741,13 @@ class ProductionExecutionService:
         run.status = RunStatus.COMPLETED
         run.save()
 
+        # Derive run cost from the Cost Master (rates x execution time).
+        try:
+            from .cost_calculator import recalculate_run_cost
+            recalculate_run_cost(run)
+        except Exception:
+            logger.exception(f"Cost recalculation failed for run {run_id}")
+
         logger.info(f"Production run {run_id} completed. Total: {run.total_production}")
 
         # NOTE: SAP goods-receipt posting on completion is disabled for now.

--- a/production_execution/services/reconciliation_reader.py
+++ b/production_execution/services/reconciliation_reader.py
@@ -6,9 +6,10 @@ against SAP:
 * **FG produced** into the finished-goods warehouse (default ``BH-PF``) =
   inward ``InQty`` with ``TransType`` = **59** (Goods Receipt) — this is the
   finished-goods receipt from production.
-* **RM/PM issued** to production = outward ``OutQty`` with ``TransType`` =
-  **202** (Production Order) — the raw/packing material consumed by the order
-  (across the material warehouses; no warehouse filter by default).
+* **RM/PM issued** to production = inward ``InQty`` with ``TransType`` =
+  **67** (Stock Transfer) into the production/packing warehouse (default
+  ``BH-PC``). SAP users approve the BOM by transferring the raw/packing
+  material *into* BH-PC, so the approved BOM lands as an inward transfer.
 * **Wastage** transferred into the wastage warehouse (default ``BH-WST``) =
   inward ``InQty`` with ``TransType`` = **67** (Stock Transfer). Scrap/rejected
   packing material is moved *into* BH-WST from the line, so it lands as an
@@ -29,7 +30,7 @@ from sap_client.hana.connection import HanaConnection
 logger = logging.getLogger(__name__)
 
 FG_TRANS_TYPES: Sequence[int] = (59,)  # Goods Receipt (FG produced)
-MATERIAL_TRANS_TYPES: Sequence[int] = (202,)  # Production Order (RM/PM issued)
+MATERIAL_TRANS_TYPES: Sequence[int] = (67,)  # Stock Transfer (BOM moved into BH-PC)
 WASTE_TRANS_TYPES: Sequence[int] = (67,)  # Stock Transfer (scrap moved into BH-WST)
 
 
@@ -43,11 +44,11 @@ class ReconciliationReader:
     def fg_by_item(self, warehouse, date_from, date_to) -> List[Dict[str, Any]]:
         return self._by_item(date_from, date_to, FG_TRANS_TYPES, "in", warehouse)
 
-    # RM/PM issued (OutQty, TransType 202, any material warehouse) -----
+    # RM/PM issued (InQty, TransType 67, into the production warehouse BH-PC)
     def material_issues_by_item(
         self, date_from, date_to, warehouse: Optional[str] = None
     ) -> List[Dict[str, Any]]:
-        return self._by_item(date_from, date_to, MATERIAL_TRANS_TYPES, "out", warehouse)
+        return self._by_item(date_from, date_to, MATERIAL_TRANS_TYPES, "in", warehouse)
 
     # Wastage transferred in (InQty, TransType 67, into the wastage warehouse)
     def wastage_by_item(self, warehouse, date_from, date_to) -> List[Dict[str, Any]]:

--- a/production_execution/services/reconciliation_service.py
+++ b/production_execution/services/reconciliation_service.py
@@ -24,8 +24,16 @@ from ..models import ProductionMaterialUsage, ProductionRun, ProductionSegment, 
 from .reconciliation_reader import ReconciliationReader
 
 DEFAULT_FG_WAREHOUSE = "BH-PF"
-DEFAULT_MATERIAL_WAREHOUSE = "BH-PM"
+DEFAULT_MATERIAL_WAREHOUSE = "BH-PC"  # SAP-approved BOM lands here (TransType 67 InQty)
 DEFAULT_WASTAGE_WAREHOUSE = "BH-WST"
+
+# The production/material warehouse where SAP-approved BOM lands differs per
+# company (Oil uses BH-PC; Beverages transfers material into BH-PP "Production
+# Process"). FG (BH-PF) and wastage (BH-WST) are the same across companies.
+MATERIAL_WAREHOUSE_BY_COMPANY = {
+    "JIVO_OIL": "BH-PC",
+    "JIVO_BEVERAGES": "BH-PP",
+}
 
 MATCH_TOLERANCE_PCT = 1.0
 
@@ -129,13 +137,20 @@ class ReconciliationService:
     # ------------------------------------------------------------------
     # Material (BOM) — should-be-used vs warehouse-issued (both from app data)
     # ------------------------------------------------------------------
-    def get_material_reconciliation(self, date_from=None, date_to=None, warehouse=None, line=None):
+    def get_material_reconciliation(
+        self, date_from=None, date_to=None, warehouse=None, line=None, sap_lag_days=0
+    ):
         # Local import avoids a warehouse↔production_execution app cycle.
         from warehouse.models import BOMRequestLine
 
         d_to = _to_date(date_to, date.today())
         d_from = _to_date(date_from, d_to)
         line_id = _to_int(line)
+        # `sap_lag_days` can widen the SAP-side BH-PC window by N days each side.
+        # Default 0 (same day): BH-PC is a shared warehouse that handles every
+        # day's material, so widening sums unrelated transfers and over-counts —
+        # only turn it on deliberately.
+        lag = max(0, _to_int(sap_lag_days) or 0)
 
         runs = ProductionRun.objects.filter(
             company=self.company, date__gte=d_from, date__lte=d_to
@@ -144,7 +159,9 @@ class ReconciliationService:
             runs = runs.filter(line_id=line_id)
         produced = self._produced_by_run(runs)  # {run_id: FG produced (cases)}
 
-        whs = warehouse or DEFAULT_MATERIAL_WAREHOUSE
+        whs = warehouse or MATERIAL_WAREHOUSE_BY_COMPANY.get(
+            self.company.code, DEFAULT_MATERIAL_WAREHOUSE
+        )
 
         # by item: should-use (FG × per-unit BOM) + app-issued (warehouse BOM issue)
         line_qs = BOMRequestLine.objects.filter(
@@ -186,10 +203,13 @@ class ReconciliationService:
             by_item.setdefault(code, {"name": u["material_name"] or code, "should": 0.0, "app": 0.0})
             by_item[code]["app"] += float(u["q"] or 0)
 
-        # SAP issued: TransType 202 from the material warehouse (BH-PM).
+        # SAP issued: BOM transferred into BH-PC (TransType 67 InQty), within a
+        # +/- lag window of the run date to catch early/late approvals.
+        sap_from = d_from - timedelta(days=lag)
+        sap_to = d_to + timedelta(days=lag)
         sap_by_code = {
             it["item_code"]: {"name": it["item_name"], "qty": float(it["sap_qty"])}
-            for it in self.reader.material_issues_by_item(d_from, d_to, whs)
+            for it in self.reader.material_issues_by_item(sap_from, sap_to, whs)
         }
 
         rows: List[Dict[str, Any]] = []
@@ -204,7 +224,7 @@ class ReconciliationService:
             key=lambda r: max(r["should_use"], r["app_issued"], r["sap_issued"]), reverse=True
         )
 
-        return self._material_envelope(rows, d_from, d_to, whs)
+        return self._material_envelope(rows, d_from, d_to, whs, lag)
 
     def _produced_by_run(self, runs) -> Dict[int, float]:
         rows = list(runs.values("id", "total_production"))
@@ -247,7 +267,7 @@ class ReconciliationService:
             "status": status,
         }
 
-    def _material_envelope(self, rows, d_from, d_to, whs):
+    def _material_envelope(self, rows, d_from, d_to, whs, lag=0):
         should = round(sum(r["should_use"] for r in rows), 3)
         app = round(sum(r["app_issued"] for r in rows), 3)
         sap = round(sum(r["sap_issued"] for r in rows), 3)
@@ -268,7 +288,9 @@ class ReconciliationService:
                 "warehouse": whs,
                 "note": "Should-use = FG produced × BOM per-unit qty. App issued = warehouse-approved "
                 "BOM qty (or issued qty once material is issued; + production material usage where no "
-                f"BOM line). SAP issued = TransType 202 from {whs}. Status compares App vs SAP issued.",
+                f"BOM line). SAP issued = BOM transferred into {whs} (TransType 67 stock transfer, "
+                + ("InQty) on the run date" if not lag else f"InQty) within +/-{lag} day(s) of the run")
+                + ", matched by item code. Status compares App vs SAP issued.",
             },
         }
 

--- a/production_execution/services/report_service.py
+++ b/production_execution/services/report_service.py
@@ -12,7 +12,8 @@ from ..models import (
     ProductionRun, RunStatus,
     ResourceElectricity, ResourceWater, ResourceGas, ResourceCompressedAir,
     ResourceLabour, ResourceMachineCost, ResourceOverhead,
-    ProductionRunCost, WasteLog, ProductionMaterialUsage,
+    ProductionRunCost, ProductionRunCostLine, CostCategory,
+    WasteLog, ProductionMaterialUsage,
     MachineBreakdown, Machine,
 )
 
@@ -721,7 +722,9 @@ class ReportService:
                 'gas_cost': float(c.gas_cost or 0),
                 'compressed_air_cost': float(c.compressed_air_cost or 0),
                 'overhead_cost': float(c.overhead_cost or 0),
+                'waste_recovery_credit': float(c.waste_recovery_credit or 0),
                 'total_cost': float(c.total_cost or 0),
+                'net_cost': float(c.net_cost or 0),
                 'per_unit_cost': float(c.per_unit_cost or 0),
             })
 
@@ -772,10 +775,14 @@ class ReportService:
             gas=Sum('gas_cost'),
             compressed_air=Sum('compressed_air_cost'),
             overhead=Sum('overhead_cost'),
+            waste_recovery=Sum('waste_recovery_credit'),
             total=Sum('total_cost'),
+            net=Sum('net_cost'),
             total_production=Sum('produced_qty'),
         )
         total = float(agg['total'] or 0)
+        total_net = float(agg['net'] or 0)
+        total_waste_recovery = float(agg['waste_recovery'] or 0)
         distribution = {}
         for key in ['raw_material', 'labour', 'machine', 'electricity', 'water', 'gas', 'compressed_air', 'overhead']:
             val = float(agg[key] or 0)
@@ -784,14 +791,39 @@ class ReportService:
                 'percentage': round(val / total * 100, 1) if total else 0,
             }
 
+        # Granular breakdown from the actual cost lines — same categories as the
+        # per-run Run Cost page (Labour, Maintenance, Supervisor/Salaried
+        # Manpower, BOM Material, Overhead, Electricity, ...).
+        cat_display = dict(CostCategory.choices)
+        line_agg = (
+            ProductionRunCostLine.objects
+            .filter(production_run_id__in=run_ids)
+            .values('category', 'is_credit')
+            .annotate(amount=Sum('amount'))
+            .order_by('-amount')
+        )
+        category_breakdown = [
+            {
+                'category': r['category'],
+                'label': cat_display.get(r['category'], r['category']),
+                'amount': round(float(r['amount'] or 0), 2),
+                'is_credit': r['is_credit'],
+                'percentage': round(float(r['amount'] or 0) / total * 100, 1) if total else 0,
+            }
+            for r in line_agg if r['amount']
+        ]
+
         return {
             'per_run': per_run,
             'trend': trend,
             'by_line': by_line,
             'cost_distribution': distribution,
+            'category_breakdown': category_breakdown,
             'summary': {
                 'total_cost': round(total, 2),
-                'avg_per_unit': round(total / float(agg['total_production'] or 1), 2),
+                'total_waste_recovery': round(total_waste_recovery, 2),
+                'total_net_cost': round(total_net, 2),
+                'avg_per_unit': round(total_net / float(agg['total_production'] or 1), 2),
                 'total_production': float(agg['total_production'] or 0),
                 'run_count': len(per_run),
             },

--- a/production_execution/urls.py
+++ b/production_execution/urls.py
@@ -59,6 +59,8 @@ from .views import (
     # Line SKU Config
     LineSkuConfigListCreateAPI, LineSkuConfigDetailAPI,
     LineSkuConfigAutoFillAPI,
+    # Cost Master
+    CostRateListCreateAPI, CostRateDetailAPI,
 )
 
 urlpatterns = [
@@ -279,4 +281,10 @@ urlpatterns = [
     path('line-configs/', LineSkuConfigListCreateAPI.as_view(), name='pe-line-config-list-create'),
     path('line-configs/<int:config_id>/', LineSkuConfigDetailAPI.as_view(), name='pe-line-config-detail'),
     path('line-configs/auto-fill/', LineSkuConfigAutoFillAPI.as_view(), name='pe-line-config-autofill'),
+
+    # ------------------------------------------------------------------
+    # Cost Master — Cost Rates
+    # ------------------------------------------------------------------
+    path('cost-rates/', CostRateListCreateAPI.as_view(), name='pe-cost-rate-list-create'),
+    path('cost-rates/<int:rate_id>/', CostRateDetailAPI.as_view(), name='pe-cost-rate-detail'),
 ]

--- a/production_execution/views.py
+++ b/production_execution/views.py
@@ -10,7 +10,8 @@ from sap_client.exceptions import SAPConnectionError, SAPDataError
 
 from .services import ProductionExecutionService, ProductionMovementService
 from .models import (
-    ProductionRun, MachineBreakdown, WasteLog, BreakdownCategory,
+    ProductionLine, ProductionRun, MachineBreakdown, WasteLog, BreakdownCategory,
+    CostRate,
     ResourceElectricity, ResourceWater, ResourceGas, ResourceCompressedAir,
     ResourceLabour, ResourceMachineCost, ResourceOverhead,
     ProductionRunCost, InProcessQCCheck, FinalQCCheck,
@@ -1183,6 +1184,7 @@ class MaterialReconciliationAPI(APIView):
                 date_to=request.GET.get("date_to"),
                 warehouse=request.GET.get("warehouse"),
                 line=request.GET.get("line"),
+                sap_lag_days=request.GET.get("sap_lag_days", 0),
             )
         except SAPConnectionError:
             return Response(
@@ -2190,6 +2192,9 @@ from .serializers import (
     LineSkuConfigSerializer,
     LineSkuConfigCreateSerializer,
     LineSkuConfigUpdateSerializer,
+    CostRateSerializer,
+    CostRateCreateSerializer,
+    CostRateUpdateSerializer,
 )
 
 
@@ -2294,3 +2299,90 @@ class LineSkuConfigAutoFillAPI(APIView):
             return Response({'config': None})
 
         return Response({'config': LineSkuConfigSerializer(config).data})
+
+
+# ===========================================================================
+# COST MASTER — Cost Rates (global defaults + per-line overrides)
+# ===========================================================================
+
+class CostRateListCreateAPI(APIView):
+    """List cost rates or create/upsert one.
+
+    Query params:
+      - ``scope=global`` → only company-wide defaults (line is null)
+      - ``line_id=<id>`` → only that line's overrides
+      - (none) → all active rates
+    """
+
+    def get_permissions(self):
+        if self.request.method == 'GET':
+            return [IsAuthenticated(), HasCompanyContext(), CanViewProductionRunOrManageLines()]
+        return [IsAuthenticated(), HasCompanyContext(), CanManageProductionLines()]
+
+    def get(self, request):
+        company = request.company.company
+        qs = CostRate.objects.filter(company=company, is_active=True).select_related('line')
+        if request.GET.get('scope') == 'global':
+            qs = qs.filter(line__isnull=True)
+        line_id = request.GET.get('line_id')
+        if line_id:
+            qs = qs.filter(line_id=line_id)
+        return Response(CostRateSerializer(qs, many=True).data)
+
+    def post(self, request):
+        serializer = CostRateCreateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        company = request.company.company
+        line_id = data.pop('line_id', None)
+
+        if line_id is not None:
+            if not ProductionLine.objects.filter(id=line_id, company=company).exists():
+                return Response({'detail': 'Production line not found.'},
+                                status=status.HTTP_404_NOT_FOUND)
+
+        # Upsert: one active rate per (company, line-or-global, category).
+        rate, _ = CostRate.objects.update_or_create(
+            company=company,
+            line_id=line_id,
+            category=data['category'],
+            is_active=True,
+            defaults={
+                'basis': data['basis'],
+                'rate': data['rate'],
+                'is_credit': data.get('is_credit', False),
+                'label': data.get('label', ''),
+            },
+        )
+        return Response(CostRateSerializer(rate).data, status=status.HTTP_201_CREATED)
+
+
+class CostRateDetailAPI(APIView):
+    """Update or delete a single cost rate."""
+
+    permission_classes = [IsAuthenticated, HasCompanyContext, CanManageProductionLines]
+
+    def _get_rate(self, request, rate_id):
+        return CostRate.objects.filter(
+            id=rate_id, company=request.company.company
+        ).select_related('line').first()
+
+    def patch(self, request, rate_id):
+        rate = self._get_rate(request, rate_id)
+        if not rate:
+            return Response({'error': 'Not found'}, status=status.HTTP_404_NOT_FOUND)
+        serializer = CostRateUpdateSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        for key, value in serializer.validated_data.items():
+            setattr(rate, key, value)
+        rate.save()
+        rate.refresh_from_db()
+        return Response(CostRateSerializer(rate).data)
+
+    def delete(self, request, rate_id):
+        rate = self._get_rate(request, rate_id)
+        if not rate:
+            return Response({'error': 'Not found'}, status=status.HTTP_404_NOT_FOUND)
+        rate.is_active = False
+        rate.save(update_fields=['is_active', 'updated_at'])
+        return Response(status=status.HTTP_204_NO_CONTENT)


### PR DESCRIPTION
- Added management command `recalc_run_costs` to backfill derived run costs based on current rates.
- Enhanced `ProductionLine` model with cost-related fields: `standard_hours_per_month`, `standard_hours_per_day`, and `electricity_units_per_hour`.
- Introduced `CostCategory`, `CostBasis`, and `CostRate` models to manage cost rates and categories.
- Updated `ProductionRunCost` model to include `waste_recovery_credit`, `net_cost`, and associated calculations.
- Created `ProductionRunCostLine` model for detailed cost breakdown per category.
- Modified `cost_calculator` service to compute costs based on new models and logic.
- Updated serializers to include new fields and models for cost rates and production run costs.
- Enhanced reconciliation services to reflect changes in material issuance and cost calculations.
- Added API endpoints for managing cost rates, including listing, creating, updating, and deleting rates.