### PR TITLE
fix(service-grpo): surface the failures that made the outage invisible

### DIFF
--- a/dispatch_plans/views.py
+++ b/dispatch_plans/views.py
@@ -744,6 +744,8 @@ class DispatchBiltyServiceGRPOPostAPI(APIView):
                 eway_bill=serializer.validated_data.get("eway_bill"),
                 invoice_weight=serializer.validated_data.get("invoice_weight"),
                 invoice_amount=serializer.validated_data.get("invoice_amount"),
+                bilty_no=serializer.validated_data.get("bilty_no"),
+                bilty_date=serializer.validated_data.get("bilty_date"),
                 comments=serializer.validated_data.get("comments"),
                 vendor_ref=serializer.validated_data.get("vendor_ref"),
                 extra_charges=serializer.validated_data.get("extra_charges"),
@@ -759,16 +761,21 @@ class DispatchBiltyServiceGRPOPostAPI(APIView):
         except ValueError as e:
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except SAPValidationError as e:
+            self._record_failure(service, serializer, request, str(e))
             return Response(
                 {"detail": f"SAP validation error: {str(e)}"},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        except SAPConnectionError:
+        except SAPConnectionError as e:
+            self._record_failure(
+                service, serializer, request, f"SAP system unavailable: {e}"
+            )
             return Response(
                 {"detail": "SAP system is currently unavailable. Please try again later."},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         except SAPDataError as e:
+            self._record_failure(service, serializer, request, str(e))
             return Response(
                 {"detail": f"SAP error: {str(e)}"},
                 status=status.HTTP_502_BAD_GATEWAY,
@@ -792,6 +799,26 @@ class DispatchBiltyServiceGRPOPostAPI(APIView):
             ).data,
             status=status.HTTP_201_CREATED,
         )
+
+    @staticmethod
+    def _record_failure(service, serializer, request, error_message):
+        """
+        Persist the failure so it shows up in Service GRPO history.
+
+        The service's ``@transaction.atomic`` rolls back the FAILED row it writes
+        internally, so without this a failed post leaves no trace anywhere — which is
+        how the Jun-Aug 2026 outage stayed invisible for seven weeks. Bookkeeping must
+        never mask the real SAP error the operator needs to see, hence the broad catch.
+        """
+        try:
+            service.record_service_grpo_failure(
+                dispatch_plan_id=serializer.validated_data["dispatch_plan_id"],
+                vendor_code=serializer.validated_data.get("vendor_code", ""),
+                error_message=error_message,
+                user=request.user,
+            )
+        except Exception:
+            logger.exception("Could not record service GRPO failure")
 
     @staticmethod
     def _parse_payload(request):

--- a/grpo/services.py
+++ b/grpo/services.py
@@ -325,6 +325,54 @@ class GRPOService:
                 except Exception:
                     pass
 
+    # SAP's notification procedure rejects any GRPO whose AtcEntry is null unless the
+    # vendor's BP GroupCode is this one, so everyone else must send a document:
+    #   If Exists(... OPDN O Join OCRD B ... O."AtcEntry" is Null and B."GroupCode"!=101)
+    #       SELECT 200019, 'Please Attach its Receiving'
+    SAP_ATTACHMENT_EXEMPT_BP_GROUP_CODE = 101
+
+    @staticmethod
+    @lru_cache(maxsize=256)
+    def _get_sap_bp_group_code(company_code: str, bp_code: str) -> Optional[int]:
+        """BP GroupCode for a vendor, or None when it cannot be read."""
+        bp_code = (bp_code or "").strip()
+        if not bp_code:
+            return None
+
+        conn = None
+        cursor = None
+        try:
+            context = CompanyContext(company_code)
+            connection = HanaConnection(context.hana)
+            conn = connection.connect()
+            cursor = conn.cursor()
+            cursor.execute(
+                f"""
+                    SELECT "GroupCode"
+                    FROM "{connection.schema}"."OCRD"
+                    WHERE "CardCode" = ?
+                """,
+                [bp_code],
+            )
+            row = cursor.fetchone()
+            return int(row[0]) if row and row[0] is not None else None
+        except Exception as exc:
+            # Never block a posting because this lookup failed — fall through and let
+            # SAP be the authority, same as before this check existed.
+            logger.warning("Could not read BP GroupCode for %s: %s", bp_code, exc)
+            return None
+        finally:
+            if cursor:
+                try:
+                    cursor.close()
+                except Exception:
+                    pass
+            if conn:
+                try:
+                    conn.close()
+                except Exception:
+                    pass
+
     @staticmethod
     @lru_cache(maxsize=256)
     def _get_sap_bp_state(company_code: str, bp_code: str) -> str:
@@ -2406,6 +2454,61 @@ class GRPOService:
             document_code=_allocate_grpo_document(filename=filename, user=user),
         )
 
+    # SAP's PurchaseDeliveryNotes notification procedure rejects service GRPOs with
+    # terse numbered messages that mean nothing to a dispatch operator. Translate the
+    # ones they actually hit into the action that clears them. The SAP text is kept
+    # so the original is still searchable in the failure record.
+    SAP_SERVICE_GRPO_ERROR_HINTS = (
+        (
+            "Please Attach its Receiving",
+            "SAP requires a document attached to this GRPO (the bilty / LR copy). "
+            "Attach the bilty on the preview page and post again.",
+        ),
+        (
+            "Please Select G/L Account",
+            "SAP requires a G/L account on every service line. Select the freight "
+            "G/L account (Freight and Cartage Outward) and post again.",
+        ),
+        (
+            "Tax Code is mandatory",
+            "SAP requires a tax code on every line. Select the tax code and post again.",
+        ),
+    )
+
+    @classmethod
+    def _humanize_sap_service_error(cls, message: str) -> str:
+        for needle, hint in cls.SAP_SERVICE_GRPO_ERROR_HINTS:
+            if needle.lower() in message.lower():
+                return f"{hint} (SAP said: {message})"
+        return message
+
+    def record_service_grpo_failure(
+        self,
+        dispatch_plan_id: int,
+        vendor_code: str,
+        error_message: str,
+        user,
+    ) -> ServiceGRPOPosting:
+        """
+        Persist a FAILED service GRPO posting.
+
+        ``post_service_grpo`` is wrapped in a single ``@transaction.atomic`` and
+        re-raises on a SAP error, so the FAILED row it writes inside that block is
+        rolled back with everything else — failures never survive. The views call
+        this from their error handlers instead: by then the service's atomic block
+        has unwound and (ATOMIC_REQUESTS is off) this create commits, so the failure
+        is visible in Service GRPO history instead of vanishing silently.
+
+        This mirrors ``record_material_grpo_failure`` for the material flow.
+        """
+        return ServiceGRPOPosting.objects.create(
+            dispatch_plan_id=dispatch_plan_id,
+            vendor_code=(vendor_code or "")[:50],
+            status=GRPOStatus.FAILED,
+            error_message=error_message,
+            posted_by=user,
+        )
+
     @transaction.atomic
     def post_service_grpo(
         self,
@@ -2498,6 +2601,29 @@ class GRPOService:
         ).strip()[:255]
         if not service_description:
             raise ValueError("Service description is required.")
+
+        # SAP rejects an attachment-less GRPO with a terse "(200019) Please Attach its
+        # Receiving" only AFTER the whole payload round-trips. Catch it here so the
+        # operator is told what to do before anything is sent.
+        attachment_sources = self._get_service_attachment_sources(
+            dispatch_plan=dispatch_plan,
+            attachments=attachments,
+            include_bilty_attachment=include_bilty_attachment,
+        )
+        if not attachment_sources:
+            group_code = self._get_sap_bp_group_code(self.company_code, vendor_code)
+            # Block only when SAP positively says this vendor needs a document. If the
+            # lookup failed (group_code is None) fall through and let SAP be the
+            # authority — our own check must never ground postings that SAP would take.
+            if (
+                group_code is not None
+                and group_code != self.SAP_ATTACHMENT_EXEMPT_BP_GROUP_CODE
+            ):
+                raise ValueError(
+                    "SAP requires the bilty / LR copy attached to this GRPO before it "
+                    f"can be booked against {vendor_code}. Attach the bilty document "
+                    "and post again."
+                )
 
         unit_price = Decimal(str(unit_price)) if unit_price is not None else amount
         place_of_supply = (place_of_supply or "").strip()
@@ -2814,17 +2940,21 @@ class GRPOService:
         sap_client = SAPClient(company_code=self.company_code)
         attachment_records = []
         sap_absolute_entry = None
-        attachment_sources = self._get_service_attachment_sources(
-            dispatch_plan=dispatch_plan,
-            attachments=attachments,
-            include_bilty_attachment=include_bilty_attachment,
-        )
 
         if attachment_sources:
             for attachment_source in attachment_sources:
                 filename = attachment_source["filename"]
                 file_obj = attachment_source["file"]
-                tmp_path = self._copy_attachment_to_temp(file_obj, filename)
+                try:
+                    tmp_path = self._copy_attachment_to_temp(file_obj, filename)
+                except OSError as exc:
+                    # The stored file is gone (media pruned/moved). Without this the
+                    # raw FileNotFoundError escapes every handler and the operator
+                    # gets a bare 500 instead of something they can act on.
+                    raise ValueError(
+                        f"Attachment '{filename}' could not be read from storage. "
+                        "Re-upload the bilty document on the preview page and post again."
+                    ) from exc
                 try:
                     if sap_absolute_entry:
                         sap_client.add_line_to_existing_attachment(
@@ -2906,11 +3036,12 @@ class GRPOService:
             return grpo_posting
 
         except SAPValidationError as e:
+            message = self._humanize_sap_service_error(str(e))
             grpo_posting.status = GRPOStatus.FAILED
-            grpo_posting.error_message = str(e)
+            grpo_posting.error_message = message
             grpo_posting.save()
             logger.error(f"SAP validation error posting service GRPO: {e}")
-            raise
+            raise SAPValidationError(message) from e
 
         except SAPConnectionError as e:
             grpo_posting.status = GRPOStatus.FAILED

--- a/grpo/tests.py
+++ b/grpo/tests.py
@@ -1812,6 +1812,119 @@ class GRPOServiceTests(TestCase):
         self.assertIn(old_dispatched.id, month_ids)
         self.assertIn(booked.id, month_ids)
 
+    def test_humanize_sap_service_error_explains_mandatory_attachment(self):
+        """SAP's '(200019) Please Attach its Receiving' must tell the operator what to do.
+
+        SAP's notification procedure rejects any OPDN with a null AtcEntry unless the
+        vendor's BP GroupCode is 101, so this is the error a bilty post hits whenever
+        no document is attached.
+        """
+        raw = '{"error": {"message": "(200019) Please Attach its Receiving"}}'
+        message = GRPOService._humanize_sap_service_error(raw)
+
+        self.assertIn("bilty", message.lower())
+        self.assertIn("attach", message.lower())
+        # The original SAP text stays searchable in the failure record.
+        self.assertIn("200019", message)
+
+    @patch.object(GRPOService, "_get_sap_bp_group_code")
+    @patch("grpo.services.SAPClient")
+    def test_service_grpo_blocks_missing_attachment_before_calling_sap(
+        self, mock_sap_client, mock_group_code
+    ):
+        """A vendor SAP requires a document for must be stopped before the round-trip."""
+        mock_group_code.return_value = 102  # not the exempt group (101)
+        dispatch_plan = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=626077956,
+            sap_invoice_doc_num="626077956",
+            booking_status=DispatchPlanStatus.DISPATCHED,
+            place_of_supply="DL",
+        )
+        service = GRPOService(company_code="TC001")
+
+        with self.assertRaisesMessage(ValueError, "bilty / LR copy"):
+            service.post_service_grpo(
+                dispatch_plan_id=dispatch_plan.id,
+                user=self.user,
+                vendor_code="VENDA000948",
+                branch_id=2,
+                service_description="Water",
+                amount=Decimal("4500.00"),
+                effective_month="2026-07",
+                include_bilty_attachment=False,
+            )
+
+        mock_sap_client.return_value.create_grpo.assert_not_called()
+
+    @patch.object(GRPOService, "_get_sap_bp_group_code")
+    @patch("grpo.services.SAPClient")
+    def test_service_grpo_attachment_check_does_not_block_when_lookup_fails(
+        self, mock_sap_client, mock_group_code
+    ):
+        """An unreadable GroupCode must not ground a posting SAP would have accepted."""
+        mock_group_code.return_value = None
+        dispatch_plan = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=626077957,
+            sap_invoice_doc_num="626077957",
+            booking_status=DispatchPlanStatus.DISPATCHED,
+            place_of_supply="DL",
+        )
+        service = GRPOService(company_code="TC001")
+
+        # It must get past the attachment gate; whatever it fails on later, it is not
+        # this check.
+        with self.assertRaises(Exception) as ctx:
+            service.post_service_grpo(
+                dispatch_plan_id=dispatch_plan.id,
+                user=self.user,
+                vendor_code="VENDA000948",
+                branch_id=2,
+                service_description="Water",
+                amount=Decimal("4500.00"),
+                effective_month="2026-07",
+                include_bilty_attachment=False,
+            )
+        self.assertNotIn("bilty / LR copy", str(ctx.exception))
+
+    def test_humanize_sap_service_error_passes_unknown_errors_through(self):
+        message = GRPOService._humanize_sap_service_error("(200099) Something new")
+        self.assertEqual(message, "(200099) Something new")
+
+    def test_record_service_grpo_failure_survives_the_service_atomic_block(self):
+        """A failed service GRPO must leave a FAILED row behind.
+
+        ``post_service_grpo`` is ``@transaction.atomic`` and re-raises, so the FAILED
+        row it writes internally is rolled back. The views call this recorder after
+        the block unwinds — without it a failure leaves no trace at all, which is how
+        the Jun-Aug 2026 outage went unnoticed for seven weeks.
+        """
+        from grpo.models import ServiceGRPOPosting
+
+        dispatch_plan = DispatchPlan.objects.create(
+            company=self.company,
+            sap_invoice_doc_entry=626077956,
+            sap_invoice_doc_num="626077956",
+            booking_status=DispatchPlanStatus.DISPATCHED,
+            place_of_supply="DL",
+        )
+        service = GRPOService(company_code="TC001")
+
+        posting = service.record_service_grpo_failure(
+            dispatch_plan_id=dispatch_plan.id,
+            vendor_code="VENDA000948",
+            error_message="(200019) Please Attach its Receiving",
+            user=self.user,
+        )
+
+        stored = ServiceGRPOPosting.objects.get(pk=posting.pk)
+        self.assertEqual(stored.status, GRPOStatus.FAILED)
+        self.assertEqual(stored.dispatch_plan_id, dispatch_plan.id)
+        self.assertEqual(stored.vendor_code, "VENDA000948")
+        self.assertIn("200019", stored.error_message)
+        self.assertIsNone(stored.sap_doc_num)
+
 
 class GRPOAPITests(APITestCase):
     """Tests for GRPO API endpoints"""

--- a/grpo/views.py
+++ b/grpo/views.py
@@ -974,6 +974,7 @@ class PostServiceGRPOAPI(APIView):
             )
 
         except SAPValidationError as e:
+            self._record_failure(service, serializer, request, str(e))
             notify_service_grpo_failed(
                 company=request.company.company,
                 user=request.user,
@@ -985,7 +986,10 @@ class PostServiceGRPOAPI(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        except SAPConnectionError:
+        except SAPConnectionError as e:
+            self._record_failure(
+                service, serializer, request, f"SAP system unavailable: {e}"
+            )
             notify_service_grpo_failed(
                 company=request.company.company,
                 user=request.user,
@@ -998,6 +1002,7 @@ class PostServiceGRPOAPI(APIView):
             )
 
         except SAPDataError as e:
+            self._record_failure(service, serializer, request, str(e))
             notify_service_grpo_failed(
                 company=request.company.company,
                 user=request.user,
@@ -1008,6 +1013,20 @@ class PostServiceGRPOAPI(APIView):
                 {"detail": f"SAP error: {str(e)}"},
                 status=status.HTTP_502_BAD_GATEWAY,
             )
+
+    @staticmethod
+    def _record_failure(service, serializer, request, error_message):
+        """Persist the failure — the service's atomic block rolls back its own
+        FAILED row. See ``GRPOService.record_service_grpo_failure``."""
+        try:
+            service.record_service_grpo_failure(
+                dispatch_plan_id=serializer.validated_data["dispatch_plan_id"],
+                vendor_code=serializer.validated_data.get("vendor_code", ""),
+                error_message=error_message,
+                user=request.user,
+            )
+        except Exception:
+            logger.exception("Could not record service GRPO failure")
 
 
 class ServiceGRPOPostingHistoryAPI(APIView):

--- a/sap_client/service_layer/grpo_writer.py
+++ b/sap_client/service_layer/grpo_writer.py
@@ -77,7 +77,11 @@ class GRPOWriter:
                 json=payload,
                 cookies=cookies,
                 headers=headers,
-                timeout=30,
+                # A service GRPO runs SAP's notification procedure plus dimension
+                # validation and can outlast 30s. Timing out early does NOT cancel
+                # the SAP-side commit, so a short timeout risks a document that
+                # exists in SAP but not here. The UI waits 5 minutes; stay under it.
+                timeout=180,
                 verify=False
             )
 


### PR DESCRIPTION
Service GRPO posting has been dead since 2026-06-15 (156 postings, then zero) while ~1,100 dispatched plans piled up, and nothing anywhere recorded why.

## Root cause of the silence

`post_service_grpo` is `@transaction.atomic` and re-raises on SAP errors, so the FAILED row each handler writes is rolled back with the rest of the transaction. Every failed attempt left no trace — empty history, no error, no audit. `record_material_grpo_failure` already documents this trap for the material flow; Service GRPO never got the equivalent. Both post views now record the failure after the atomic block unwinds.

## Root cause of the rejection

SAP's notification procedure rejects any OPDN whose `AtcEntry` is null unless the vendor's BP GroupCode is 101:

```sql
If Exists(... OPDN O Join OCRD B ... O."AtcEntry" is Null and B."GroupCode"!=101)
    SELECT 200019, 'Please Attach its Receiving'
```

So the bilty/LR copy is mandatory for ordinary transporters. We sent attachment-less payloads and relayed SAP's terse code verbatim. The vendor's GroupCode is now checked up front and the post is blocked with an actionable message before the round-trip. The check **fails open**: if the GroupCode cannot be read it defers to SAP rather than grounding a posting SAP would have accepted.

## Also fixed (all found while tracing a live post)

- Known SAP codes (200019/200014/200020) get an instruction; raw SAP text kept so it stays searchable.
- A missing attachment file raised a bare `FileNotFoundError` that escaped every handler as a 500; now a 400.
- The dispatch post view silently dropped `bilty_no`/`bilty_date`, so a bilty typed on the form never reached SAP.
- GRPO write timeout 30s -> 180s. A timeout does not cancel SAP's commit, so the short window risked a document existing in SAP but not here.

## Testing

- 182 tests in `grpo` / `dispatch_plans` / `sap_client`; 5 new regression tests pass.
- The 9 `AttachmentWriterTests` failures are **pre-existing on main** (verified by running the same suite on clean `origin/main`) and unchanged by this commit.
- Verified live against prod SAP: the pre-flight blocks with a clear 400, and the FAILED row now persists.

No migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)